### PR TITLE
[Feature] blackjack/hand-holder ドメインの実装

### DIFF
--- a/src/domains/blackjack/hand-holder/handHolder.stories.tsx
+++ b/src/domains/blackjack/hand-holder/handHolder.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from '../../core/card/card.types';
+import { createHand } from '../hand/hand.utils';
+import {
+  createHandHolder,
+  updateHandHolderStatus,
+  getAvailableActions,
+  addCardToHandHolder,
+} from './handHolder.utils';
+import { HandHolder } from './handHolder.types';
+
+const meta = {
+  title: 'Domains/Blackjack/HandHolder',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createCard = (rank: string, suit: string, faceUp = true): Card => ({
+  rank: rank as Card['rank'],
+  suit: suit as Card['suit'],
+  faceUp,
+});
+
+const HandHolderDisplay = ({ holder }: { holder: HandHolder }) => {
+  const actions = getAvailableActions(holder);
+  
+  return (
+    <div style={{ padding: '20px', border: '1px solid #ccc', borderRadius: '8px' }}>
+      <h3>HandHolder: {holder.id}</h3>
+      <p>Type: {holder.type}</p>
+      <p>Status: {holder.status}</p>
+      <p>Hand Value: {holder.hand.value}</p>
+      {holder.hand.softValue && <p>Soft Value: {holder.hand.softValue}</p>}
+      <p>Cards: {holder.hand.cards.length}</p>
+      <div style={{ marginTop: '10px' }}>
+        <h4>Available Actions:</h4>
+        <ul>
+          <li>Can Hit: {actions.canHit ? '✓' : '✗'}</li>
+          <li>Can Stand: {actions.canStand ? '✓' : '✗'}</li>
+          <li>Can Double: {actions.canDouble ? '✓' : '✗'}</li>
+          <li>Can Split: {actions.canSplit ? '✓' : '✗'}</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export const DealerWaiting: Story = {
+  render: () => {
+    const holder = createHandHolder('dealer-1', 'dealer');
+    return <HandHolderDisplay holder={holder} />;
+  },
+};
+
+export const ParticipantActive: Story = {
+  render: () => {
+    const holder = createHandHolder('player-1', 'participant');
+    const cards = [createCard('7', 'hearts'), createCard('8', 'spades')];
+    const hand = createHand(cards);
+    const activeHolder: HandHolder = { ...holder, hand, status: 'active' };
+    return <HandHolderDisplay holder={activeHolder} />;
+  },
+};
+
+export const ParticipantBlackjack: Story = {
+  render: () => {
+    const holder = createHandHolder('player-1', 'participant');
+    const cards = [createCard('A', 'spades'), createCard('K', 'hearts')];
+    const hand = createHand(cards);
+    const holderWithCards: HandHolder = { ...holder, hand, status: 'active' };
+    const updatedHolder = updateHandHolderStatus(holderWithCards);
+    return <HandHolderDisplay holder={updatedHolder} />;
+  },
+};
+
+export const ParticipantBust: Story = {
+  render: () => {
+    const holder = createHandHolder('player-1', 'participant');
+    const cards = [
+      createCard('K', 'spades'),
+      createCard('Q', 'hearts'),
+      createCard('5', 'diamonds'),
+    ];
+    const hand = createHand(cards);
+    const holderWithCards: HandHolder = { ...holder, hand, status: 'active' };
+    const updatedHolder = updateHandHolderStatus(holderWithCards);
+    return <HandHolderDisplay holder={updatedHolder} />;
+  },
+};
+
+export const ParticipantCanSplit: Story = {
+  render: () => {
+    const holder = createHandHolder('player-1', 'participant');
+    const cards = [createCard('8', 'spades'), createCard('8', 'hearts')];
+    const hand = createHand(cards);
+    const activeHolder: HandHolder = { ...holder, hand, status: 'active' };
+    return <HandHolderDisplay holder={activeHolder} />;
+  },
+};
+
+export const ParticipantCanDouble: Story = {
+  render: () => {
+    const holder = createHandHolder('player-1', 'participant');
+    const cards = [createCard('5', 'spades'), createCard('6', 'hearts')];
+    const hand = createHand(cards);
+    const activeHolder: HandHolder = { ...holder, hand, status: 'active' };
+    return <HandHolderDisplay holder={activeHolder} />;
+  },
+};
+
+export const DealerActive: Story = {
+  render: () => {
+    const holder = createHandHolder('dealer-1', 'dealer');
+    const cards = [createCard('7', 'hearts'), createCard('9', 'spades')];
+    const hand = createHand(cards);
+    const activeHolder: HandHolder = { ...holder, hand, status: 'active' };
+    return <HandHolderDisplay holder={activeHolder} />;
+  },
+};
+
+export const AddCardDemo: Story = {
+  render: () => {
+    let holder = createHandHolder('player-1', 'participant');
+    holder = { ...holder, status: 'active' };
+    
+    const card1 = createCard('7', 'hearts');
+    holder = addCardToHandHolder(holder, card1);
+    
+    const card2 = createCard('8', 'spades');
+    holder = addCardToHandHolder(holder, card2);
+    
+    return (
+      <div>
+        <h3>After adding 7♥ and 8♠:</h3>
+        <HandHolderDisplay holder={holder} />
+      </div>
+    );
+  },
+};

--- a/src/domains/blackjack/hand-holder/handHolder.types.ts
+++ b/src/domains/blackjack/hand-holder/handHolder.types.ts
@@ -1,0 +1,21 @@
+import { Hand } from '../hand/hand.types';
+
+export type HandHolderType = 'dealer' | 'participant';
+
+export type HandHolderStatus = 'waiting' | 'active' | 'stand' | 'bust' | 'blackjack';
+
+export type HandHolderAction = 'hit' | 'stand' | 'double' | 'split';
+
+export type HandHolder = {
+  readonly id: string;
+  readonly type: HandHolderType;
+  readonly hand: Hand;
+  readonly status: HandHolderStatus;
+};
+
+export type ActionAvailability = {
+  readonly canHit: boolean;
+  readonly canStand: boolean;
+  readonly canDouble: boolean;
+  readonly canSplit: boolean;
+};

--- a/src/domains/blackjack/hand-holder/handHolder.utils.test.ts
+++ b/src/domains/blackjack/hand-holder/handHolder.utils.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createHandHolder,
+  updateHandHolderStatus,
+  canPerformAction,
+  getAvailableActions,
+  addCardToHandHolder,
+  canSplit,
+  canDouble,
+} from './handHolder.utils';
+import { HandHolder, HandHolderStatus } from './handHolder.types';
+import { Card } from '../../core/card/card.types';
+import { createHand } from '../hand/hand.utils';
+
+describe('handHolder.utils', () => {
+  const createCard = (rank: string, suit: string): Card => ({
+    rank: rank as Card['rank'],
+    suit: suit as Card['suit'],
+    faceUp: true,
+  });
+
+  describe('createHandHolder', () => {
+    it('should create a dealer HandHolder', () => {
+      const holder = createHandHolder('dealer-1', 'dealer');
+      
+      expect(holder).toEqual({
+        id: 'dealer-1',
+        type: 'dealer',
+        hand: createHand([]),
+        status: 'waiting',
+      });
+    });
+
+    it('should create a participant HandHolder', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      
+      expect(holder).toEqual({
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([]),
+        status: 'waiting',
+      });
+    });
+  });
+
+  describe('updateHandHolderStatus', () => {
+    it('should update status to blackjack when hand is blackjack', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      const cards = [createCard('A', 'spades'), createCard('K', 'hearts')];
+      const hand = createHand(cards);
+      const holderWithCards: HandHolder = { ...holder, hand };
+
+      const updated = updateHandHolderStatus(holderWithCards);
+      
+      expect(updated.status).toBe('blackjack');
+    });
+
+    it('should update status to bust when hand is bust', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      const cards = [
+        createCard('K', 'spades'),
+        createCard('Q', 'hearts'),
+        createCard('5', 'diamonds'),
+      ];
+      const hand = createHand(cards);
+      const holderWithCards: HandHolder = { ...holder, hand };
+
+      const updated = updateHandHolderStatus(holderWithCards);
+      
+      expect(updated.status).toBe('bust');
+    });
+
+    it('should keep active status when hand is playable', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      const cards = [createCard('7', 'spades'), createCard('8', 'hearts')];
+      const hand = createHand(cards);
+      const holderWithCards: HandHolder = { ...holder, hand, status: 'active' };
+
+      const updated = updateHandHolderStatus(holderWithCards);
+      
+      expect(updated.status).toBe('active');
+    });
+
+    it('should not change waiting or stand status', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      
+      const waitingHolder = { ...holder, status: 'waiting' as HandHolderStatus };
+      expect(updateHandHolderStatus(waitingHolder).status).toBe('waiting');
+      
+      const standHolder = { ...holder, status: 'stand' as HandHolderStatus };
+      expect(updateHandHolderStatus(standHolder).status).toBe('stand');
+    });
+  });
+
+  describe('canPerformAction', () => {
+    it('should return true for hit when status is active and not bust', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('7', 'spades'), createCard('8', 'hearts')]),
+        status: 'active',
+      };
+
+      expect(canPerformAction(holder, 'hit')).toBe(true);
+    });
+
+    it('should return false for hit when status is bust', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([]),
+        status: 'bust',
+      };
+
+      expect(canPerformAction(holder, 'hit')).toBe(false);
+    });
+
+    it('should return true for stand when status is active', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('7', 'spades'), createCard('8', 'hearts')]),
+        status: 'active',
+      };
+
+      expect(canPerformAction(holder, 'stand')).toBe(true);
+    });
+
+    it('should return true for double when participant has exactly 2 cards and status is active', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('5', 'spades'), createCard('6', 'hearts')]),
+        status: 'active',
+      };
+
+      expect(canPerformAction(holder, 'double')).toBe(true);
+    });
+
+    it('should return false for double when dealer', () => {
+      const holder: HandHolder = {
+        id: 'dealer-1',
+        type: 'dealer',
+        hand: createHand([createCard('5', 'spades'), createCard('6', 'hearts')]),
+        status: 'active',
+      };
+
+      expect(canPerformAction(holder, 'double')).toBe(false);
+    });
+
+    it('should return true for split when participant has matching rank cards', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('8', 'spades'), createCard('8', 'hearts')]),
+        status: 'active',
+      };
+
+      expect(canPerformAction(holder, 'split')).toBe(true);
+    });
+  });
+
+  describe('getAvailableActions', () => {
+    it('should return all available actions for a participant with splittable hand', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('8', 'spades'), createCard('8', 'hearts')]),
+        status: 'active',
+      };
+
+      const actions = getAvailableActions(holder);
+      
+      expect(actions).toEqual({
+        canHit: true,
+        canStand: true,
+        canDouble: true,
+        canSplit: true,
+      });
+    });
+
+    it('should return limited actions for dealer', () => {
+      const holder: HandHolder = {
+        id: 'dealer-1',
+        type: 'dealer',
+        hand: createHand([createCard('7', 'spades'), createCard('8', 'hearts')]),
+        status: 'active',
+      };
+
+      const actions = getAvailableActions(holder);
+      
+      expect(actions).toEqual({
+        canHit: true,
+        canStand: true,
+        canDouble: false,
+        canSplit: false,
+      });
+    });
+
+    it('should return no actions when bust', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([]),
+        status: 'bust',
+      };
+
+      const actions = getAvailableActions(holder);
+      
+      expect(actions).toEqual({
+        canHit: false,
+        canStand: false,
+        canDouble: false,
+        canSplit: false,
+      });
+    });
+  });
+
+  describe('addCardToHandHolder', () => {
+    it('should add card and update status', () => {
+      const holder = createHandHolder('player-1', 'participant');
+      const activeHolder = { ...holder, status: 'active' as HandHolderStatus };
+      const card = createCard('A', 'spades');
+
+      const updated = addCardToHandHolder(activeHolder, card);
+      
+      expect(updated.hand.cards).toHaveLength(1);
+      expect(updated.hand.cards[0]).toEqual(card);
+    });
+
+    it('should update status to blackjack when achieving blackjack', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('A', 'spades')]),
+        status: 'active',
+      };
+      const card = createCard('K', 'hearts');
+
+      const updated = addCardToHandHolder(holder, card);
+      
+      expect(updated.status).toBe('blackjack');
+    });
+
+    it('should update status to bust when exceeding 21', () => {
+      const holder: HandHolder = {
+        id: 'player-1',
+        type: 'participant',
+        hand: createHand([createCard('K', 'spades'), createCard('Q', 'hearts')]),
+        status: 'active',
+      };
+      const card = createCard('5', 'diamonds');
+
+      const updated = addCardToHandHolder(holder, card);
+      
+      expect(updated.status).toBe('bust');
+    });
+  });
+
+  describe('canSplit', () => {
+    it('should return true when two cards have same rank', () => {
+      const cards = [createCard('8', 'spades'), createCard('8', 'hearts')];
+      expect(canSplit(cards)).toBe(true);
+    });
+
+    it('should return false when two cards have different ranks', () => {
+      const cards = [createCard('8', 'spades'), createCard('9', 'hearts')];
+      expect(canSplit(cards)).toBe(false);
+    });
+
+    it('should return false when not exactly 2 cards', () => {
+      expect(canSplit([createCard('8', 'spades')])).toBe(false);
+      expect(canSplit([
+        createCard('8', 'spades'),
+        createCard('8', 'hearts'),
+        createCard('8', 'diamonds'),
+      ])).toBe(false);
+    });
+
+    it('should return true for face cards with same rank', () => {
+      const cards = [createCard('K', 'spades'), createCard('K', 'hearts')];
+      expect(canSplit(cards)).toBe(true);
+    });
+
+    it('should return false for different face cards', () => {
+      const cards = [createCard('K', 'spades'), createCard('Q', 'hearts')];
+      expect(canSplit(cards)).toBe(false);
+    });
+  });
+
+  describe('canDouble', () => {
+    it('should return true when exactly 2 cards', () => {
+      const cards = [createCard('5', 'spades'), createCard('6', 'hearts')];
+      expect(canDouble(cards)).toBe(true);
+    });
+
+    it('should return false when not exactly 2 cards', () => {
+      expect(canDouble([createCard('5', 'spades')])).toBe(false);
+      expect(canDouble([
+        createCard('5', 'spades'),
+        createCard('6', 'hearts'),
+        createCard('2', 'diamonds'),
+      ])).toBe(false);
+    });
+  });
+});

--- a/src/domains/blackjack/hand-holder/handHolder.utils.ts
+++ b/src/domains/blackjack/hand-holder/handHolder.utils.ts
@@ -1,0 +1,81 @@
+import { Card } from '../../core/card/card.types';
+import { createHand, addCardToHand } from '../hand/hand.utils';
+import {
+  HandHolder,
+  HandHolderType,
+  HandHolderAction,
+  ActionAvailability,
+} from './handHolder.types';
+
+const INITIAL_CARD_COUNT = 2;
+
+export const createHandHolder = (id: string, type: HandHolderType): HandHolder => {
+  return {
+    id,
+    type,
+    hand: createHand([]),
+    status: 'waiting',
+  };
+};
+
+export const updateHandHolderStatus = (holder: HandHolder): HandHolder => {
+  if (holder.status === 'stand') {
+    return holder;
+  }
+
+  if (holder.hand.isBlackjack) {
+    return { ...holder, status: 'blackjack' };
+  }
+
+  if (holder.hand.isBust) {
+    return { ...holder, status: 'bust' };
+  }
+
+  return holder;
+};
+
+export const canSplit = (cards: Card[]): boolean => {
+  if (cards.length !== INITIAL_CARD_COUNT) {
+    return false;
+  }
+
+  return cards[0].rank === cards[1].rank;
+};
+
+export const canDouble = (cards: Card[]): boolean => {
+  return cards.length === INITIAL_CARD_COUNT;
+};
+
+export const canPerformAction = (holder: HandHolder, action: HandHolderAction): boolean => {
+  if (holder.status !== 'active') {
+    return false;
+  }
+
+  switch (action) {
+    case 'hit':
+      return !holder.hand.isBust;
+    case 'stand':
+      return true;
+    case 'double':
+      return holder.type === 'participant' && canDouble(holder.hand.cards);
+    case 'split':
+      return holder.type === 'participant' && canSplit(holder.hand.cards);
+    default:
+      return false;
+  }
+};
+
+export const getAvailableActions = (holder: HandHolder): ActionAvailability => {
+  return {
+    canHit: canPerformAction(holder, 'hit'),
+    canStand: canPerformAction(holder, 'stand'),
+    canDouble: canPerformAction(holder, 'double'),
+    canSplit: canPerformAction(holder, 'split'),
+  };
+};
+
+export const addCardToHandHolder = (holder: HandHolder, card: Card): HandHolder => {
+  const newHand = addCardToHand(holder.hand, card);
+  const updatedHolder = { ...holder, hand: newHand };
+  return updateHandHolderStatus(updatedHolder);
+};


### PR DESCRIPTION
## 概要
Issue #10 に対応し、ディーラーと参加者（プレイヤー/CPU）の共通インターフェースとして、手札を持つ者（HandHolder）のドメインを実装しました。

## 実装内容
### 基本機能
- HandHolder型の定義（手札を持つ者の共通インターフェース）
- 手札の状態管理（waiting, active, stand, bust, blackjack）
- アクション可能性の判定（ヒット、スタンド、ダブルダウン、スプリット）
- カードの追加と状態の自動更新

### ファイル構成
```
src/domains/blackjack/hand-holder/
├── handHolder.types.ts        # HandHolder型の定義
├── handHolder.utils.ts        # 手札操作の共通ロジック
├── handHolder.utils.test.ts   # ユニットテスト（全機能をカバー）
└── handHolder.stories.tsx     # Storybookストーリー
```

## 設計の特徴
- **責務の分離**: 状態管理とルール判定のみを担当（意思決定はBrainドメインへ）
- **共通インターフェース**: ディーラーと参加者の共通部分を抽象化
- **不変性**: すべての関数は純粋関数として実装
- **型安全性**: TypeScript strict modeで型安全を保証

## テスト
- TDD（テスト駆動開発）で実装
- 全てのユーティリティ関数に対する単体テスト
- lint、typecheck、testすべてパス

## 関連Issue
- Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)