### PR TITLE
[Refactor] core/player を単一プレイヤー用にリファクタリング

### DIFF
--- a/src/domains/core/player/player.hook.test.ts
+++ b/src/domains/core/player/player.hook.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePlayer } from "./player.hook";
+import { usePlayerStore } from "./player.store";
+import { createCoin } from "../coin/coin.utils";
+
+describe("player.hook", () => {
+  beforeEach(() => {
+    // Reset store before each test
+    usePlayerStore.getState().reset();
+  });
+
+  describe("usePlayer", () => {
+    it("should return current player state", () => {
+      const { result } = renderHook(() => usePlayer());
+      
+      expect(result.current.player.name).toBe("Player");
+      expect(result.current.player.coin.value).toBe(100);
+    });
+
+    it("should update coin", () => {
+      const { result } = renderHook(() => usePlayer());
+      const newCoin = createCoin(500);
+      
+      act(() => {
+        result.current.updateCoin(newCoin);
+      });
+      
+      expect(result.current.player.coin.value).toBe(500);
+    });
+
+    it("should update name", () => {
+      const { result } = renderHook(() => usePlayer());
+      
+      act(() => {
+        result.current.updateName("Alice");
+      });
+      
+      expect(result.current.player.name).toBe("Alice");
+    });
+
+    it("should reset player", () => {
+      const { result } = renderHook(() => usePlayer());
+      const newCoin = createCoin(1000);
+      
+      act(() => {
+        result.current.updateCoin(newCoin);
+        result.current.updateName("Bob");
+      });
+      
+      expect(result.current.player.name).toBe("Bob");
+      expect(result.current.player.coin.value).toBe(1000);
+      
+      act(() => {
+        result.current.reset();
+      });
+      
+      expect(result.current.player.name).toBe("Player");
+      expect(result.current.player.coin.value).toBe(100);
+    });
+  });
+});

--- a/src/domains/core/player/player.hook.ts
+++ b/src/domains/core/player/player.hook.ts
@@ -1,0 +1,12 @@
+import { usePlayerStore } from "./player.store";
+
+export const usePlayer = () => {
+  const { player, updateCoin, updateName, reset } = usePlayerStore();
+  
+  return {
+    player,
+    updateCoin,
+    updateName,
+    reset,
+  };
+};

--- a/src/domains/core/player/player.store.test.ts
+++ b/src/domains/core/player/player.store.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { usePlayerStore } from "./player.store";
+import { createCoin } from "../coin/coin.utils";
+
+describe("player.store", () => {
+  beforeEach(() => {
+    // Reset store before each test
+    usePlayerStore.getState().reset();
+  });
+
+  describe("initial state", () => {
+    it("should have default player with initial coin value", () => {
+      const state = usePlayerStore.getState();
+      expect(state.player.name).toBe("Player");
+      expect(state.player.coin.value).toBe(100);
+    });
+  });
+
+  describe("updateCoin", () => {
+    it("should update player's coin", () => {
+      const store = usePlayerStore.getState();
+      const newCoin = createCoin(500);
+      
+      store.updateCoin(newCoin);
+      
+      const updatedState = usePlayerStore.getState();
+      expect(updatedState.player.coin.value).toBe(500);
+    });
+  });
+
+  describe("updateName", () => {
+    it("should update player's name", () => {
+      const store = usePlayerStore.getState();
+      
+      store.updateName("Alice");
+      
+      const updatedState = usePlayerStore.getState();
+      expect(updatedState.player.name).toBe("Alice");
+    });
+  });
+
+  describe("reset", () => {
+    it("should reset player to initial state", () => {
+      const store = usePlayerStore.getState();
+      const newCoin = createCoin(1000);
+      
+      store.updateCoin(newCoin);
+      store.updateName("Bob");
+      
+      store.reset();
+      
+      const resetState = usePlayerStore.getState();
+      expect(resetState.player.name).toBe("Player");
+      expect(resetState.player.coin.value).toBe(100);
+    });
+  });
+});

--- a/src/domains/core/player/player.store.ts
+++ b/src/domains/core/player/player.store.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import type { Player } from "./player.types";
+import type { Coin } from "../coin/coin.types";
+import { createPlayer, updatePlayerCoin, updatePlayerName } from "./player.utils";
+import { createCoin } from "../coin/coin.utils";
+
+type PlayerStore = {
+  player: Player;
+  updateCoin: (coin: Coin) => void;
+  updateName: (name: string) => void;
+  reset: () => void;
+};
+
+const initialPlayer = createPlayer("Player", createCoin(100));
+
+export const usePlayerStore = create<PlayerStore>((set) => ({
+  player: initialPlayer,
+  
+  updateCoin: (coin) =>
+    set((state) => ({
+      player: updatePlayerCoin(state.player, coin),
+    })),
+    
+  updateName: (name) =>
+    set((state) => ({
+      player: updatePlayerName(state.player, name),
+    })),
+    
+  reset: () =>
+    set(() => ({
+      player: initialPlayer,
+    })),
+}));

--- a/src/domains/core/player/player.types.ts
+++ b/src/domains/core/player/player.types.ts
@@ -1,7 +1,6 @@
 import type { Coin } from "../coin/coin.types";
 
 export type Player = {
-  readonly id: string;
   readonly name: string;
   readonly coin: Coin;
 };

--- a/src/domains/core/player/player.utils.test.ts
+++ b/src/domains/core/player/player.utils.test.ts
@@ -1,23 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { createPlayer, updatePlayerCoin } from "./player.utils";
+import { createPlayer, updatePlayerCoin, updatePlayerName } from "./player.utils";
 import { createCoin } from "../coin/coin.utils";
 
 describe("player.utils", () => {
   describe("createPlayer", () => {
     it("should create a player with given properties", () => {
       const coin = createCoin(1000);
-      const player = createPlayer("player1", "Alice", coin);
+      const player = createPlayer("Alice", coin);
       
-      expect(player.id).toBe("player1");
       expect(player.name).toBe("Alice");
       expect(player.coin.value).toBe(1000);
     });
 
     it("should create a player with zero coins", () => {
       const coin = createCoin(0);
-      const player = createPlayer("player2", "Bob", coin);
+      const player = createPlayer("Bob", coin);
       
-      expect(player.id).toBe("player2");
       expect(player.name).toBe("Bob");
       expect(player.coin.value).toBe(0);
     });
@@ -26,22 +24,42 @@ describe("player.utils", () => {
   describe("updatePlayerCoin", () => {
     it("should update player's coin", () => {
       const initialCoin = createCoin(1000);
-      const player = createPlayer("player1", "Alice", initialCoin);
+      const player = createPlayer("Alice", initialCoin);
       
       const newCoin = createCoin(2000);
       const updatedPlayer = updatePlayerCoin(player, newCoin);
       
-      expect(updatedPlayer.id).toBe("player1");
       expect(updatedPlayer.name).toBe("Alice");
       expect(updatedPlayer.coin.value).toBe(2000);
     });
 
     it("should return a new player object", () => {
       const coin = createCoin(1000);
-      const player = createPlayer("player1", "Alice", coin);
+      const player = createPlayer("Alice", coin);
       
       const newCoin = createCoin(2000);
       const updatedPlayer = updatePlayerCoin(player, newCoin);
+      
+      expect(updatedPlayer).not.toBe(player);
+    });
+  });
+
+  describe("updatePlayerName", () => {
+    it("should update player's name", () => {
+      const coin = createCoin(1000);
+      const player = createPlayer("Alice", coin);
+      
+      const updatedPlayer = updatePlayerName(player, "Bob");
+      
+      expect(updatedPlayer.name).toBe("Bob");
+      expect(updatedPlayer.coin.value).toBe(1000);
+    });
+
+    it("should return a new player object", () => {
+      const coin = createCoin(1000);
+      const player = createPlayer("Alice", coin);
+      
+      const updatedPlayer = updatePlayerName(player, "Bob");
       
       expect(updatedPlayer).not.toBe(player);
     });

--- a/src/domains/core/player/player.utils.ts
+++ b/src/domains/core/player/player.utils.ts
@@ -1,8 +1,7 @@
 import type { Player } from "./player.types";
 import type { Coin } from "../coin/coin.types";
 
-export const createPlayer = (id: string, name: string, coin: Coin): Player => ({
-  id,
+export const createPlayer = (name: string, coin: Coin): Player => ({
   name,
   coin,
 });
@@ -10,4 +9,9 @@ export const createPlayer = (id: string, name: string, coin: Coin): Player => ({
 export const updatePlayerCoin = (player: Player, coin: Coin): Player => ({
   ...player,
   coin,
+});
+
+export const updatePlayerName = (player: Player, name: string): Player => ({
+  ...player,
+  name,
 });


### PR DESCRIPTION
## 概要
Player型を単一プレイヤー用にリファクタリングし、Zustandでシングルトン管理するように変更しました。

## 変更内容
### Player型の簡素化
- IDフィールドを削除（単一プレイヤーのため不要）
- nameとcoinのみのシンプルな構造に変更

### 状態管理の実装
- `player.store.ts`: Zustandでシングルトン管理
- `player.hook.ts`: ViewとStoreの接続用フック
- 初期状態: 名前"Player"、100コイン

### 新機能
- `updatePlayerName`: プレイヤー名の更新機能を追加
- `reset`: プレイヤーを初期状態に戻す機能

### テスト
- すべてのテストを新しい実装に合わせて更新
- store、hook用の新しいテストを追加
- 全テスト（14テスト）が成功

## 技術的詳細
- TypeScript strict mode準拠
- イミュータブルな更新パターンを維持
- 既存のコード規約に従った実装

## 関連Issue
Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)