### PR TITLE
[Feature] blackjack/brain ドメインの実装

### DIFF
--- a/src/domains/blackjack/brain/basicStrategy.test.ts
+++ b/src/domains/blackjack/brain/basicStrategy.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { getBasicStrategyDecision, createBasicStrategyTable } from './basicStrategy';
+import type { Card } from '../../core/card/card.types';
+import type { Hand } from '../hand/hand.types';
+import type { DecisionContext } from './brain.types';
+
+describe('basicStrategy', () => {
+  const createMockHand = (cards: Card[], value: number, softValue?: number): Hand => ({
+    cards,
+    value,
+    softValue,
+    isBust: false,
+    isBlackjack: false,
+  });
+
+  const createMockCard = (rank: string, suit = 'hearts'): Card => ({
+    rank: rank as Card['rank'],
+    suit: suit as Card['suit'],
+  });
+
+  describe('getBasicStrategyDecision', () => {
+    describe('hard hands', () => {
+      it('should hit on hard 8 or less', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('5'), createMockCard('3')], 8),
+          dealerUpCard: createMockCard('10'),
+          canDouble: true,
+          canSplit: false,
+          canSurrender: true,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+
+      it('should double on hard 11 vs dealer 2-10', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('6'), createMockCard('5')], 11),
+          dealerUpCard: createMockCard('7'),
+          canDouble: true,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('double');
+      });
+
+      it('should hit on hard 11 vs dealer Ace when double not allowed', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('6'), createMockCard('5')], 11),
+          dealerUpCard: createMockCard('A'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+
+      it('should stand on hard 17+ against any dealer card', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+          dealerUpCard: createMockCard('A'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('stand');
+      });
+
+      it('should surrender hard 16 vs dealer 9, 10, A when allowed', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('10'), createMockCard('6')], 16),
+          dealerUpCard: createMockCard('10'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: true,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('surrender');
+      });
+
+      it('should hit hard 16 vs dealer 10 when surrender not allowed', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('10'), createMockCard('6')], 16),
+          dealerUpCard: createMockCard('10'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+
+      it('should stand on hard 12 vs dealer 4-6', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('8'), createMockCard('4')], 12),
+          dealerUpCard: createMockCard('5'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('stand');
+      });
+    });
+
+    describe('soft hands', () => {
+      it('should double soft 13-14 (A,2-3) vs dealer 5-6', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('2')], 13, 13),
+          dealerUpCard: createMockCard('6'),
+          canDouble: true,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('double');
+      });
+
+      it('should hit soft 13-14 vs dealer 5-6 when double not allowed', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('2')], 13, 13),
+          dealerUpCard: createMockCard('6'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+
+      it('should stand on soft 19-21', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('8')], 19, 19),
+          dealerUpCard: createMockCard('10'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('stand');
+      });
+
+      it('should double soft 18 vs dealer 3-6', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('7')], 18, 18),
+          dealerUpCard: createMockCard('4'),
+          canDouble: true,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('double');
+      });
+
+      it('should hit soft 18 vs dealer 9, 10, A', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('7')], 18, 18),
+          dealerUpCard: createMockCard('A'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+    });
+
+    describe('pairs', () => {
+      it('should always split Aces', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('A'), createMockCard('A')], 12, 12),
+          dealerUpCard: createMockCard('10'),
+          canDouble: false,
+          canSplit: true,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('split');
+      });
+
+      it('should always split 8s', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('8'), createMockCard('8')], 16),
+          dealerUpCard: createMockCard('A'),
+          canDouble: false,
+          canSplit: true,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('split');
+      });
+
+      it('should never split 10s', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
+          dealerUpCard: createMockCard('6'),
+          canDouble: false,
+          canSplit: true,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('stand');
+      });
+
+      it('should split 2s and 3s vs dealer 2-7', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('3'), createMockCard('3')], 6),
+          dealerUpCard: createMockCard('5'),
+          canDouble: false,
+          canSplit: true,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('split');
+      });
+
+      it('should not split 2s and 3s vs dealer 8+', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('3'), createMockCard('3')], 6),
+          dealerUpCard: createMockCard('8'),
+          canDouble: false,
+          canSplit: true,
+          canSurrender: false,
+          canInsurance: false,
+        };
+        expect(getBasicStrategyDecision(context)).toBe('hit');
+      });
+
+      it('should handle pair strategy when split not allowed', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('8'), createMockCard('8')], 16),
+          dealerUpCard: createMockCard('10'),
+          canDouble: false,
+          canSplit: false, // Split not allowed
+          canSurrender: true,
+          canInsurance: false,
+        };
+        // Should fall back to hard hand strategy (surrender 16 vs 10)
+        expect(getBasicStrategyDecision(context)).toBe('surrender');
+      });
+    });
+
+    describe('insurance', () => {
+      it('should never take insurance', () => {
+        const context: DecisionContext = {
+          hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
+          dealerUpCard: createMockCard('A'),
+          canDouble: false,
+          canSplit: false,
+          canSurrender: false,
+          canInsurance: true,
+        };
+        // Should continue with regular decision
+        expect(getBasicStrategyDecision(context)).toBe('stand');
+      });
+    });
+  });
+
+  describe('createBasicStrategyTable', () => {
+    it('should create a strategy table object', () => {
+      const table = createBasicStrategyTable();
+      
+      expect(table).toHaveProperty('hard');
+      expect(table).toHaveProperty('soft');
+      expect(table).toHaveProperty('pairs');
+      
+      // Check some specific entries
+      expect(table.hard[11]).toBeDefined();
+      expect(table.soft[18]).toBeDefined();
+      expect(table.pairs['A']).toBeDefined();
+    });
+  });
+});

--- a/src/domains/blackjack/brain/basicStrategy.ts
+++ b/src/domains/blackjack/brain/basicStrategy.ts
@@ -1,0 +1,147 @@
+import type { Decision, DecisionContext } from './brain.types';
+import type { Card } from '../../core/card/card.types';
+
+type StrategyAction = 'H' | 'S' | 'D' | 'Dh' | 'P' | 'Ph' | 'Rh' | 'Rs' | 'Rp';
+type DealerCard = '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | 'A';
+
+const actionMap: Record<StrategyAction, { primary: Decision; fallback?: Decision }> = {
+  H: { primary: 'hit' },
+  S: { primary: 'stand' },
+  D: { primary: 'double', fallback: 'hit' },
+  Dh: { primary: 'double', fallback: 'hit' },
+  P: { primary: 'split' },
+  Ph: { primary: 'split', fallback: 'hit' },
+  Rh: { primary: 'surrender', fallback: 'hit' },
+  Rs: { primary: 'surrender', fallback: 'stand' },
+  Rp: { primary: 'surrender', fallback: 'split' },
+};
+
+const hardStrategy: Record<number, Record<DealerCard, StrategyAction>> = {
+  8: { '2': 'H', '3': 'H', '4': 'H', '5': 'H', '6': 'H', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  9: { '2': 'H', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  10: { '2': 'Dh', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'Dh', '8': 'Dh', '9': 'Dh', '10': 'H', 'A': 'H' },
+  11: { '2': 'Dh', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'Dh', '8': 'Dh', '9': 'Dh', '10': 'Dh', 'A': 'H' },
+  12: { '2': 'H', '3': 'H', '4': 'S', '5': 'S', '6': 'S', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  13: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  14: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  15: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'H', '8': 'H', '9': 'H', '10': 'Rh', 'A': 'Rh' },
+  16: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'H', '8': 'H', '9': 'Rh', '10': 'Rh', 'A': 'Rh' },
+  17: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  18: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  19: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  20: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  21: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+};
+
+const softStrategy: Record<number, Record<DealerCard, StrategyAction>> = {
+  13: { '2': 'H', '3': 'H', '4': 'H', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  14: { '2': 'H', '3': 'H', '4': 'H', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  15: { '2': 'H', '3': 'H', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  16: { '2': 'H', '3': 'H', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  17: { '2': 'H', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  18: { '2': 'S', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'S', '8': 'S', '9': 'H', '10': 'H', 'A': 'H' },
+  19: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  20: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  21: { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+};
+
+const pairStrategy: Record<string, Record<DealerCard, StrategyAction>> = {
+  'A': { '2': 'P', '3': 'P', '4': 'P', '5': 'P', '6': 'P', '7': 'P', '8': 'P', '9': 'P', '10': 'P', 'A': 'P' },
+  '10': { '2': 'S', '3': 'S', '4': 'S', '5': 'S', '6': 'S', '7': 'S', '8': 'S', '9': 'S', '10': 'S', 'A': 'S' },
+  '9': { '2': 'P', '3': 'P', '4': 'P', '5': 'P', '6': 'P', '7': 'S', '8': 'P', '9': 'P', '10': 'S', 'A': 'S' },
+  '8': { '2': 'P', '3': 'P', '4': 'P', '5': 'P', '6': 'P', '7': 'P', '8': 'P', '9': 'P', '10': 'P', 'A': 'P' },
+  '7': { '2': 'P', '3': 'P', '4': 'P', '5': 'P', '6': 'P', '7': 'P', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  '6': { '2': 'Ph', '3': 'P', '4': 'P', '5': 'P', '6': 'P', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  '5': { '2': 'Dh', '3': 'Dh', '4': 'Dh', '5': 'Dh', '6': 'Dh', '7': 'Dh', '8': 'Dh', '9': 'Dh', '10': 'H', 'A': 'H' },
+  '4': { '2': 'H', '3': 'H', '4': 'H', '5': 'Ph', '6': 'Ph', '7': 'H', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  '3': { '2': 'Ph', '3': 'Ph', '4': 'P', '5': 'P', '6': 'P', '7': 'P', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+  '2': { '2': 'Ph', '3': 'Ph', '4': 'P', '5': 'P', '6': 'P', '7': 'P', '8': 'H', '9': 'H', '10': 'H', 'A': 'H' },
+};
+
+const getDealerCardValue = (card: Card): DealerCard => {
+  if (card.rank === 'A') return 'A';
+  if (['K', 'Q', 'J'].includes(card.rank)) return '10';
+  return card.rank as DealerCard;
+};
+
+const isPair = (context: DecisionContext): boolean => {
+  const { hand } = context;
+  if (hand.cards.length !== 2) return false;
+  return hand.cards[0].rank === hand.cards[1].rank;
+};
+
+const isSoftHand = (context: DecisionContext): boolean => {
+  return context.hand.softValue !== undefined;
+};
+
+export const getBasicStrategyDecision = (context: DecisionContext): Decision => {
+  const dealerCard = getDealerCardValue(context.dealerUpCard);
+
+  // Check for pairs first
+  if (context.canSplit && isPair(context)) {
+    const pairRank = context.hand.cards[0].rank;
+    const pairKey = ['K', 'Q', 'J'].includes(pairRank) ? '10' : pairRank;
+    const action = pairStrategy[pairKey]?.[dealerCard];
+    
+    if (action) {
+      const { primary, fallback } = actionMap[action];
+      if (primary === 'split' && context.canSplit) {
+        return primary;
+      }
+      if (fallback) {
+        return fallback;
+      }
+    }
+  }
+
+  // Check for soft hands
+  if (isSoftHand(context)) {
+    const softValue = context.hand.softValue || context.hand.value;
+    const action = softStrategy[softValue]?.[dealerCard];
+    
+    if (action) {
+      const { primary, fallback } = actionMap[action];
+      if (primary === 'double' && context.canDouble) {
+        return primary;
+      }
+      if (fallback) {
+        return fallback;
+      }
+      return primary;
+    }
+  }
+
+  // Hard hand strategy
+  const handValue = context.hand.value;
+  let action: StrategyAction | undefined;
+
+  if (handValue <= 8) {
+    action = 'H';
+  } else if (handValue >= 17) {
+    action = 'S';
+  } else {
+    action = hardStrategy[handValue]?.[dealerCard];
+  }
+
+  if (action) {
+    const { primary, fallback } = actionMap[action];
+    
+    if (primary === 'double' && !context.canDouble && fallback) {
+      return fallback;
+    }
+    if (primary === 'surrender' && !context.canSurrender && fallback) {
+      return fallback;
+    }
+    
+    return primary;
+  }
+
+  // Default to stand if no strategy found
+  return 'stand';
+};
+
+export const createBasicStrategyTable = () => ({
+  hard: hardStrategy,
+  soft: softStrategy,
+  pairs: pairStrategy,
+});

--- a/src/domains/blackjack/brain/brain.stories.tsx
+++ b/src/domains/blackjack/brain/brain.stories.tsx
@@ -1,0 +1,395 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { createBasicStrategyTable } from './basicStrategy';
+import { createEasyCpuBrain, createNormalCpuBrain, createHardCpuBrain } from './cpuBrain';
+import type { Decision, DecisionContext, Brain } from './brain.types';
+import type { Card } from '../../core/card/card.types';
+import type { Hand } from '../hand/hand.types';
+
+const meta = {
+  title: 'Domains/Blackjack/Brain',
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createMockHand = (cards: Card[], value: number, softValue?: number): Hand => ({
+  cards,
+  value,
+  softValue,
+  isBust: false,
+  isBlackjack: false,
+});
+
+const createMockCard = (rank: string, suit = 'hearts'): Card => ({
+  rank: rank as Card['rank'],
+  suit: suit as Card['suit'],
+});
+
+// Basic Strategy Table Visualization
+const BasicStrategyTable = () => {
+  const table = createBasicStrategyTable();
+  const dealerCards = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'A'];
+  
+  const getDecisionColor = (decision: string) => {
+    const colors: Record<string, string> = {
+      H: '#ff6b6b',   // Hit - Red
+      S: '#51cf66',   // Stand - Green
+      D: '#4c6ef5',   // Double - Blue
+      Dh: '#748ffc',  // Double if allowed, else Hit - Light Blue
+      P: '#f59f00',   // Split - Orange
+      Ph: '#fab005',  // Split if allowed, else Hit - Light Orange
+      Rh: '#495057',  // Surrender if allowed, else Hit - Dark Gray
+      Rs: '#868e96',  // Surrender if allowed, else Stand - Gray
+    };
+    return colors[decision] || '#dee2e6';
+  };
+
+  const getDecisionText = (decision: string) => {
+    const texts: Record<string, string> = {
+      H: 'H',
+      S: 'S',
+      D: 'D',
+      Dh: 'Dh',
+      P: 'P',
+      Ph: 'Ph',
+      Rh: 'Rh',
+      Rs: 'Rs',
+    };
+    return texts[decision] || decision;
+  };
+
+  return (
+    <div style={{ fontFamily: 'monospace' }}>
+      <h3>Hard Hands</h3>
+      <table style={{ borderCollapse: 'collapse', marginBottom: '2rem' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #dee2e6', padding: '8px' }}>Hand</th>
+            {dealerCards.map(card => (
+              <th key={card} style={{ border: '1px solid #dee2e6', padding: '8px' }}>{card}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(table.hard).map(([handValue, decisions]) => (
+            <tr key={handValue}>
+              <td style={{ border: '1px solid #dee2e6', padding: '8px', fontWeight: 'bold' }}>
+                {handValue}
+              </td>
+              {dealerCards.map(dealerCard => (
+                <td
+                  key={dealerCard}
+                  style={{
+                    border: '1px solid #dee2e6',
+                    padding: '8px',
+                    backgroundColor: getDecisionColor(decisions[dealerCard as keyof typeof decisions]),
+                    color: 'white',
+                    textAlign: 'center',
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {getDecisionText(decisions[dealerCard as keyof typeof decisions])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Soft Hands</h3>
+      <table style={{ borderCollapse: 'collapse', marginBottom: '2rem' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #dee2e6', padding: '8px' }}>Hand</th>
+            {dealerCards.map(card => (
+              <th key={card} style={{ border: '1px solid #dee2e6', padding: '8px' }}>{card}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(table.soft).map(([handValue, decisions]) => (
+            <tr key={handValue}>
+              <td style={{ border: '1px solid #dee2e6', padding: '8px', fontWeight: 'bold' }}>
+                A,{Number(handValue) - 11}
+              </td>
+              {dealerCards.map(dealerCard => (
+                <td
+                  key={dealerCard}
+                  style={{
+                    border: '1px solid #dee2e6',
+                    padding: '8px',
+                    backgroundColor: getDecisionColor(decisions[dealerCard as keyof typeof decisions]),
+                    color: 'white',
+                    textAlign: 'center',
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {getDecisionText(decisions[dealerCard as keyof typeof decisions])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pairs</h3>
+      <table style={{ borderCollapse: 'collapse', marginBottom: '2rem' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #dee2e6', padding: '8px' }}>Pair</th>
+            {dealerCards.map(card => (
+              <th key={card} style={{ border: '1px solid #dee2e6', padding: '8px' }}>{card}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(table.pairs).map(([pairCard, decisions]) => (
+            <tr key={pairCard}>
+              <td style={{ border: '1px solid #dee2e6', padding: '8px', fontWeight: 'bold' }}>
+                {pairCard},{pairCard}
+              </td>
+              {dealerCards.map(dealerCard => (
+                <td
+                  key={dealerCard}
+                  style={{
+                    border: '1px solid #dee2e6',
+                    padding: '8px',
+                    backgroundColor: getDecisionColor(decisions[dealerCard as keyof typeof decisions]),
+                    color: 'white',
+                    textAlign: 'center',
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {getDecisionText(decisions[dealerCard as keyof typeof decisions])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ marginTop: '1rem' }}>
+        <h4>Legend:</h4>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+          <span>H = Hit</span>
+          <span>S = Stand</span>
+          <span>D = Double</span>
+          <span>Dh = Double if allowed, else Hit</span>
+          <span>P = Split</span>
+          <span>Ph = Split if allowed, else Hit</span>
+          <span>Rh = Surrender if allowed, else Hit</span>
+          <span>Rs = Surrender if allowed, else Stand</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const BasicStrategy: Story = {
+  render: () => <BasicStrategyTable />,
+};
+
+// Decision Simulator
+const DecisionSimulator = () => {
+  const [playerCards, setPlayerCards] = useState<Card[]>([
+    createMockCard('10'),
+    createMockCard('6'),
+  ]);
+  const [dealerUpCard, setDealerUpCard] = useState<Card>(createMockCard('10'));
+  const [canDouble, setCanDouble] = useState(true);
+  const [canSplit, setCanSplit] = useState(false);
+  const [canSurrender, setCanSurrender] = useState(true);
+  const [canInsurance, setCanInsurance] = useState(false);
+
+  const calculateHandValue = (cards: Card[]): { value: number; softValue?: number } => {
+    let value = 0;
+    let aces = 0;
+
+    for (const card of cards) {
+      if (card.rank === 'A') {
+        aces++;
+        value += 11;
+      } else if (['K', 'Q', 'J'].includes(card.rank)) {
+        value += 10;
+      } else {
+        value += parseInt(card.rank);
+      }
+    }
+
+    while (value > 21 && aces > 0) {
+      value -= 10;
+      aces--;
+    }
+
+    const softValue = aces > 0 && value <= 21 ? value : undefined;
+    return { value, softValue };
+  };
+
+  const { value, softValue } = calculateHandValue(playerCards);
+  const hand = createMockHand(playerCards, value, softValue);
+
+  const context: DecisionContext = {
+    hand,
+    dealerUpCard,
+    canDouble,
+    canSplit,
+    canSurrender,
+    canInsurance,
+  };
+
+  const brains: Record<string, Brain> = {
+    'Basic Strategy': createNormalCpuBrain(),
+    'Easy CPU': createEasyCpuBrain(),
+    'Hard CPU': createHardCpuBrain(),
+  };
+
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+  return (
+    <div style={{ fontFamily: 'monospace' }}>
+      <h3>Decision Simulator</h3>
+      
+      <div style={{ marginBottom: '2rem' }}>
+        <h4>Player Hand</h4>
+        <div style={{ display: 'flex', gap: '10px', marginBottom: '10px' }}>
+          {playerCards.map((card, index) => (
+            <select
+              key={index}
+              value={card.rank}
+              onChange={(e) => {
+                const newCards = [...playerCards];
+                newCards[index] = createMockCard(e.target.value);
+                setPlayerCards(newCards);
+                // Update canSplit based on new cards
+                if (newCards.length === 2 && newCards[0].rank === newCards[1].rank) {
+                  setCanSplit(true);
+                } else {
+                  setCanSplit(false);
+                }
+              }}
+              style={{ padding: '5px' }}
+            >
+              {ranks.map(rank => (
+                <option key={rank} value={rank}>{rank}</option>
+              ))}
+            </select>
+          ))}
+          <button
+            onClick={() => setPlayerCards([...playerCards, createMockCard('2')])}
+            style={{ padding: '5px' }}
+          >
+            Add Card
+          </button>
+          {playerCards.length > 2 && (
+            <button
+              onClick={() => setPlayerCards(playerCards.slice(0, -1))}
+              style={{ padding: '5px' }}
+            >
+              Remove Card
+            </button>
+          )}
+        </div>
+        <div>Hand Value: {value}{softValue && softValue !== value && ` (soft ${softValue})`}</div>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h4>Dealer Up Card</h4>
+        <select
+          value={dealerUpCard.rank}
+          onChange={(e) => {
+            setDealerUpCard(createMockCard(e.target.value));
+            // Update canInsurance based on dealer card
+            setCanInsurance(e.target.value === 'A');
+          }}
+          style={{ padding: '5px' }}
+        >
+          {ranks.map(rank => (
+            <option key={rank} value={rank}>{rank}</option>
+          ))}
+        </select>
+      </div>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h4>Available Actions</h4>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={canDouble}
+              onChange={(e) => setCanDouble(e.target.checked)}
+            />
+            Can Double
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={canSplit}
+              onChange={(e) => setCanSplit(e.target.checked)}
+              disabled={playerCards.length !== 2 || playerCards[0].rank !== playerCards[1].rank}
+            />
+            Can Split {playerCards.length !== 2 || playerCards[0].rank !== playerCards[1].rank ? '(requires pair)' : ''}
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={canSurrender}
+              onChange={(e) => setCanSurrender(e.target.checked)}
+            />
+            Can Surrender
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={canInsurance}
+              onChange={(e) => setCanInsurance(e.target.checked)}
+              disabled={dealerUpCard.rank !== 'A'}
+            />
+            Can Insurance {dealerUpCard.rank !== 'A' ? '(requires dealer Ace)' : ''}
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <h4>Decisions</h4>
+        <table style={{ borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #dee2e6', padding: '8px' }}>Strategy</th>
+              <th style={{ border: '1px solid #dee2e6', padding: '8px' }}>Decision</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(brains).map(([name, brain]) => {
+              let decision: Decision;
+              try {
+                decision = brain.makeDecision(context);
+              } catch {
+                decision = 'stand' as Decision;
+              }
+              
+              return (
+                <tr key={name}>
+                  <td style={{ border: '1px solid #dee2e6', padding: '8px' }}>{name}</td>
+                  <td style={{ 
+                    border: '1px solid #dee2e6', 
+                    padding: '8px',
+                    fontWeight: 'bold',
+                    textTransform: 'uppercase'
+                  }}>
+                    {decision}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export const Simulator: Story = {
+  render: () => <DecisionSimulator />,
+};

--- a/src/domains/blackjack/brain/brain.types.ts
+++ b/src/domains/blackjack/brain/brain.types.ts
@@ -1,0 +1,26 @@
+import type { Card } from '../../core/card/card.types';
+import type { Hand } from '../hand/hand.types';
+
+export type Decision = 'hit' | 'stand' | 'double' | 'split' | 'surrender' | 'insurance';
+
+export type BrainType = 'human' | 'cpu-easy' | 'cpu-normal' | 'cpu-hard';
+
+export type DecisionContext = {
+  hand: Hand;
+  dealerUpCard: Card;
+  canDouble: boolean;
+  canSplit: boolean;
+  canSurrender: boolean;
+  canInsurance: boolean;
+};
+
+export type Brain = {
+  type: BrainType;
+  makeDecision: (context: DecisionContext) => Decision;
+};
+
+export type DecisionHistory = {
+  context: DecisionContext;
+  decision: Decision;
+  timestamp: number;
+};

--- a/src/domains/blackjack/brain/brain.utils.test.ts
+++ b/src/domains/blackjack/brain/brain.utils.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { createHumanBrain, isValidDecision, validateDecisionContext } from './brain.utils';
+import type { Card } from '../../core/card/card.types';
+import type { Hand } from '../hand/hand.types';
+import type { Decision, DecisionContext } from './brain.types';
+
+describe('brain.utils', () => {
+  const createMockHand = (cards: Card[], value: number, isBust = false, isBlackjack = false): Hand => ({
+    cards,
+    value,
+    isBust,
+    isBlackjack,
+  });
+
+  const createMockCard = (rank: string, suit = 'hearts'): Card => ({
+    rank: rank as Card['rank'],
+    suit: suit as Card['suit'],
+  });
+
+  describe('createHumanBrain', () => {
+    it('should create a human brain with correct type', () => {
+      const brain = createHumanBrain();
+      expect(brain.type).toBe('human');
+    });
+
+    it('should have makeDecision function', () => {
+      const brain = createHumanBrain();
+      expect(typeof brain.makeDecision).toBe('function');
+    });
+
+    it('should throw error when makeDecision is called (requires user input)', () => {
+      const brain = createHumanBrain();
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+        dealerUpCard: createMockCard('A'),
+        canDouble: true,
+        canSplit: false,
+        canSurrender: true,
+        canInsurance: true,
+      };
+      
+      expect(() => brain.makeDecision(context)).toThrow('Human decision requires user input');
+    });
+  });
+
+  describe('isValidDecision', () => {
+    const context: DecisionContext = {
+      hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
+      dealerUpCard: createMockCard('7'),
+      canDouble: true,
+      canSplit: true,
+      canSurrender: true,
+      canInsurance: false,
+    };
+
+    it('should return true for always valid decisions', () => {
+      expect(isValidDecision('hit', context)).toBe(true);
+      expect(isValidDecision('stand', context)).toBe(true);
+    });
+
+    it('should validate double based on context', () => {
+      expect(isValidDecision('double', context)).toBe(true);
+      expect(isValidDecision('double', { ...context, canDouble: false })).toBe(false);
+    });
+
+    it('should validate split based on context', () => {
+      expect(isValidDecision('split', context)).toBe(true);
+      expect(isValidDecision('split', { ...context, canSplit: false })).toBe(false);
+    });
+
+    it('should validate surrender based on context', () => {
+      expect(isValidDecision('surrender', context)).toBe(true);
+      expect(isValidDecision('surrender', { ...context, canSurrender: false })).toBe(false);
+    });
+
+    it('should validate insurance based on context', () => {
+      expect(isValidDecision('insurance', { ...context, canInsurance: true })).toBe(true);
+      expect(isValidDecision('insurance', context)).toBe(false);
+    });
+
+    it('should return false for invalid decision', () => {
+      expect(isValidDecision('invalid' as Decision, context)).toBe(false);
+    });
+  });
+
+  describe('validateDecisionContext', () => {
+    it('should not throw for valid context', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+        dealerUpCard: createMockCard('A'),
+        canDouble: true,
+        canSplit: false,
+        canSurrender: true,
+        canInsurance: true,
+      };
+
+      expect(() => validateDecisionContext(context)).not.toThrow();
+    });
+
+    it('should throw for bust hand', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('10'), createMockCard('5')], 25, true),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+
+      expect(() => validateDecisionContext(context)).toThrow('Cannot make decision on bust hand');
+    });
+
+    it('should throw for blackjack hand', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('A'), createMockCard('K')], 21, false, true),
+        dealerUpCard: createMockCard('7'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+
+      expect(() => validateDecisionContext(context)).toThrow('Cannot make decision on blackjack hand');
+    });
+
+    it('should throw for empty hand', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([], 0),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+
+      expect(() => validateDecisionContext(context)).toThrow('Hand must have cards');
+    });
+
+    it('should throw for invalid context flags', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('5'), createMockCard('6')], 11),
+        dealerUpCard: createMockCard('A'),
+        canDouble: true,
+        canSplit: true, // Cannot split non-pair
+        canSurrender: false,
+        canInsurance: false,
+      };
+
+      expect(() => validateDecisionContext(context)).toThrow('Invalid context: cannot split non-pair');
+    });
+
+    it('should validate pair for split', () => {
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('8'), createMockCard('8')], 16),
+        dealerUpCard: createMockCard('A'),
+        canDouble: true,
+        canSplit: true, // Valid for pair
+        canSurrender: true,
+        canInsurance: false,
+      };
+
+      expect(() => validateDecisionContext(context)).not.toThrow();
+    });
+
+    it('should validate dealer ace for insurance', () => {
+      const contextWithInsurance: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: true, // Valid with dealer Ace
+      };
+
+      expect(() => validateDecisionContext(contextWithInsurance)).not.toThrow();
+
+      const contextWithoutAce: DecisionContext = {
+        ...contextWithInsurance,
+        dealerUpCard: createMockCard('7'),
+      };
+
+      expect(() => validateDecisionContext(contextWithoutAce)).toThrow('Invalid context: insurance only available with dealer Ace');
+    });
+  });
+});

--- a/src/domains/blackjack/brain/brain.utils.test.ts
+++ b/src/domains/blackjack/brain/brain.utils.test.ts
@@ -39,7 +39,7 @@ describe('brain.utils', () => {
         canInsurance: true,
       };
       
-      expect(() => brain.makeDecision(context)).toThrow('Human decision requires user input');
+      expect(() => brain.makeDecision(context)).toThrow('Human decision requires user input - use UI interaction to get player decision');
     });
   });
 

--- a/src/domains/blackjack/brain/brain.utils.ts
+++ b/src/domains/blackjack/brain/brain.utils.ts
@@ -3,7 +3,7 @@ import type { Brain, Decision, DecisionContext } from './brain.types';
 export const createHumanBrain = (): Brain => ({
   type: 'human',
   makeDecision: (): Decision => {
-    throw new Error('Human decision requires user input');
+    throw new Error('Human decision requires user input - use UI interaction to get player decision');
   },
 });
 

--- a/src/domains/blackjack/brain/brain.utils.ts
+++ b/src/domains/blackjack/brain/brain.utils.ts
@@ -1,0 +1,77 @@
+import type { Brain, Decision, DecisionContext } from './brain.types';
+
+export const createHumanBrain = (): Brain => ({
+  type: 'human',
+  makeDecision: (): Decision => {
+    throw new Error('Human decision requires user input');
+  },
+});
+
+export const isValidDecision = (decision: Decision, context: DecisionContext): boolean => {
+  switch (decision) {
+    case 'hit':
+    case 'stand':
+      return true;
+    case 'double':
+      return context.canDouble;
+    case 'split':
+      return context.canSplit;
+    case 'surrender':
+      return context.canSurrender;
+    case 'insurance':
+      return context.canInsurance;
+    default:
+      return false;
+  }
+};
+
+export const validateDecisionContext = (context: DecisionContext): void => {
+  const { hand, dealerUpCard, canSplit, canInsurance } = context;
+
+  if (hand.isBust) {
+    throw new Error('Cannot make decision on bust hand');
+  }
+
+  if (hand.isBlackjack) {
+    throw new Error('Cannot make decision on blackjack hand');
+  }
+
+  if (hand.cards.length === 0) {
+    throw new Error('Hand must have cards');
+  }
+
+  // Validate split: can only split pairs
+  if (canSplit && hand.cards.length === 2) {
+    const [card1, card2] = hand.cards;
+    if (card1.rank !== card2.rank) {
+      throw new Error('Invalid context: cannot split non-pair');
+    }
+  }
+
+  // Validate insurance: only available when dealer shows Ace
+  if (canInsurance && dealerUpCard.rank !== 'A') {
+    throw new Error('Invalid context: insurance only available with dealer Ace');
+  }
+};
+
+export const getAvailableDecisions = (context: DecisionContext): Decision[] => {
+  const decisions: Decision[] = ['hit', 'stand'];
+
+  if (context.canDouble) {
+    decisions.push('double');
+  }
+
+  if (context.canSplit) {
+    decisions.push('split');
+  }
+
+  if (context.canSurrender) {
+    decisions.push('surrender');
+  }
+
+  if (context.canInsurance) {
+    decisions.push('insurance');
+  }
+
+  return decisions;
+};

--- a/src/domains/blackjack/brain/cpuBrain.test.ts
+++ b/src/domains/blackjack/brain/cpuBrain.test.ts
@@ -146,7 +146,9 @@ describe('cpuBrain', () => {
     });
 
     it('should use basic strategy by default', () => {
-      const brain = createHardCpuBrain();
+      // Use a fixed RNG value that won't trigger deviations
+      const mockRng = vi.fn().mockReturnValue(0.0); // Neutral count
+      const brain = createHardCpuBrain(mockRng);
       
       // Test that it follows basic strategy when no card counting info
       const context: DecisionContext = {
@@ -163,11 +165,9 @@ describe('cpuBrain', () => {
     });
 
     it('should make conservative decisions with high remaining deck value', () => {
-      const brain = createHardCpuBrain();
-      
       // Simulate high card rich deck (positive count)
-      const mockRandom = vi.spyOn(Math, 'random');
-      mockRandom.mockReturnValue(0.9); // High value simulating positive count
+      const mockRng = vi.fn().mockReturnValue(0.9); // High value simulating positive count
+      const brain = createHardCpuBrain(mockRng);
       
       const context: DecisionContext = {
         hand: createMockHand([createMockCard('10'), createMockCard('6')], 16),
@@ -181,16 +181,12 @@ describe('cpuBrain', () => {
       // Should be more likely to surrender/stand with high count on 16 vs 10
       const decision = brain.makeDecision(context);
       expect(['surrender', 'stand']).toContain(decision);
-      
-      mockRandom.mockRestore();
     });
 
     it('should make aggressive decisions with low remaining deck value', () => {
-      const brain = createHardCpuBrain();
-      
       // Simulate low card rich deck (negative count)
-      const mockRandom = vi.spyOn(Math, 'random');
-      mockRandom.mockReturnValue(0.1); // Low value simulating negative count
+      const mockRng = vi.fn().mockReturnValue(0.1); // Low value simulating negative count
+      const brain = createHardCpuBrain(mockRng);
       
       const context: DecisionContext = {
         hand: createMockHand([createMockCard('10'), createMockCard('2')], 12),
@@ -204,16 +200,12 @@ describe('cpuBrain', () => {
       // Should be more likely to hit with negative count on 12 vs 3
       const decision = brain.makeDecision(context);
       expect(decision).toBe('hit');
-      
-      mockRandom.mockRestore();
     });
 
     it('should take insurance with high count vs dealer Ace', () => {
-      const brain = createHardCpuBrain();
-      
       // Simulate very high card rich deck
-      const mockRandom = vi.spyOn(Math, 'random');
-      mockRandom.mockReturnValue(0.95);
+      const mockRng = vi.fn().mockReturnValue(0.95);
+      const brain = createHardCpuBrain(mockRng);
       
       const context: DecisionContext = {
         hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
@@ -227,8 +219,6 @@ describe('cpuBrain', () => {
       // Should take insurance with very high count
       const decision = brain.makeDecision(context);
       expect(decision).toBe('insurance');
-      
-      mockRandom.mockRestore();
     });
   });
 
@@ -249,11 +239,11 @@ describe('cpuBrain', () => {
     });
 
     it('should throw error for invalid brain type', () => {
-      expect(() => createCpuBrain('invalid' as BrainType)).toThrow('Invalid CPU brain type: invalid');
+      expect(() => createCpuBrain('invalid' as BrainType)).toThrow('Invalid CPU brain type: invalid. Valid types are: cpu-easy, cpu-normal, cpu-hard');
     });
 
     it('should throw error for human brain type', () => {
-      expect(() => createCpuBrain('human' as BrainType)).toThrow('Invalid CPU brain type: human');
+      expect(() => createCpuBrain('human' as BrainType)).toThrow('Invalid CPU brain type: human. Valid types are: cpu-easy, cpu-normal, cpu-hard');
     });
   });
 });

--- a/src/domains/blackjack/brain/cpuBrain.test.ts
+++ b/src/domains/blackjack/brain/cpuBrain.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest';
+import { 
+  createEasyCpuBrain, 
+  createNormalCpuBrain, 
+  createHardCpuBrain,
+  createCpuBrain 
+} from './cpuBrain';
+import type { Card } from '../../core/card/card.types';
+import type { Hand } from '../hand/hand.types';
+import type { DecisionContext, BrainType } from './brain.types';
+
+describe('cpuBrain', () => {
+  const createMockHand = (cards: Card[], value: number, softValue?: number): Hand => ({
+    cards,
+    value,
+    softValue,
+    isBust: false,
+    isBlackjack: false,
+  });
+
+  const createMockCard = (rank: string, suit = 'hearts'): Card => ({
+    rank: rank as Card['rank'],
+    suit: suit as Card['suit'],
+  });
+
+  describe('createEasyCpuBrain', () => {
+    it('should create cpu-easy brain with correct type', () => {
+      const brain = createEasyCpuBrain();
+      expect(brain.type).toBe('cpu-easy');
+    });
+
+    it('should make random but valid decisions', () => {
+      const brain = createEasyCpuBrain();
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('5')], 15),
+        dealerUpCard: createMockCard('7'),
+        canDouble: true,
+        canSplit: false,
+        canSurrender: true,
+        canInsurance: false,
+      };
+
+      // Run multiple times to check randomness
+      const decisions = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        const decision = brain.makeDecision(context);
+        decisions.add(decision);
+        expect(['hit', 'stand', 'double', 'surrender']).toContain(decision);
+      }
+
+      // Should make at least 2 different decisions (showing randomness)
+      expect(decisions.size).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should only make valid decisions based on context', () => {
+      const brain = createEasyCpuBrain();
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: true,
+      };
+
+      // Run multiple times
+      for (let i = 0; i < 50; i++) {
+        const decision = brain.makeDecision(context);
+        // Only hit, stand, and insurance should be possible
+        expect(['hit', 'stand', 'insurance']).toContain(decision);
+      }
+    });
+
+    it('should have bias towards safe plays on good hands', () => {
+      const brain = createEasyCpuBrain();
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
+        dealerUpCard: createMockCard('6'),
+        canDouble: true,
+        canSplit: true,
+        canSurrender: true,
+        canInsurance: false,
+      };
+
+      let standCount = 0;
+      const iterations = 100;
+      
+      for (let i = 0; i < iterations; i++) {
+        const decision = brain.makeDecision(context);
+        if (decision === 'stand') standCount++;
+      }
+
+      // Should mostly stand on 20
+      expect(standCount / iterations).toBeGreaterThan(0.7);
+    });
+  });
+
+  describe('createNormalCpuBrain', () => {
+    it('should create cpu-normal brain with correct type', () => {
+      const brain = createNormalCpuBrain();
+      expect(brain.type).toBe('cpu-normal');
+    });
+
+    it('should follow basic strategy', () => {
+      const brain = createNormalCpuBrain();
+      
+      // Test basic strategy decision: always hit on 8 or less
+      const context1: DecisionContext = {
+        hand: createMockHand([createMockCard('5'), createMockCard('3')], 8),
+        dealerUpCard: createMockCard('10'),
+        canDouble: true,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+      expect(brain.makeDecision(context1)).toBe('hit');
+
+      // Test basic strategy decision: stand on hard 17+
+      const context2: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('7')], 17),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+      expect(brain.makeDecision(context2)).toBe('stand');
+
+      // Test basic strategy decision: always split Aces
+      const context3: DecisionContext = {
+        hand: createMockHand([createMockCard('A'), createMockCard('A')], 12, 12),
+        dealerUpCard: createMockCard('10'),
+        canDouble: false,
+        canSplit: true,
+        canSurrender: false,
+        canInsurance: false,
+      };
+      expect(brain.makeDecision(context3)).toBe('split');
+    });
+  });
+
+  describe('createHardCpuBrain', () => {
+    it('should create cpu-hard brain with correct type', () => {
+      const brain = createHardCpuBrain();
+      expect(brain.type).toBe('cpu-hard');
+    });
+
+    it('should use basic strategy by default', () => {
+      const brain = createHardCpuBrain();
+      
+      // Test that it follows basic strategy when no card counting info
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('8'), createMockCard('8')], 16),
+        dealerUpCard: createMockCard('10'),
+        canDouble: false,
+        canSplit: true,
+        canSurrender: false,
+        canInsurance: false,
+      };
+      
+      // Basic strategy says always split 8s
+      expect(brain.makeDecision(context)).toBe('split');
+    });
+
+    it('should make conservative decisions with high remaining deck value', () => {
+      const brain = createHardCpuBrain();
+      
+      // Simulate high card rich deck (positive count)
+      const mockRandom = vi.spyOn(Math, 'random');
+      mockRandom.mockReturnValue(0.9); // High value simulating positive count
+      
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('6')], 16),
+        dealerUpCard: createMockCard('10'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: true,
+        canInsurance: false,
+      };
+      
+      // Should be more likely to surrender/stand with high count on 16 vs 10
+      const decision = brain.makeDecision(context);
+      expect(['surrender', 'stand']).toContain(decision);
+      
+      mockRandom.mockRestore();
+    });
+
+    it('should make aggressive decisions with low remaining deck value', () => {
+      const brain = createHardCpuBrain();
+      
+      // Simulate low card rich deck (negative count)
+      const mockRandom = vi.spyOn(Math, 'random');
+      mockRandom.mockReturnValue(0.1); // Low value simulating negative count
+      
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('2')], 12),
+        dealerUpCard: createMockCard('3'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: false,
+      };
+      
+      // Should be more likely to hit with negative count on 12 vs 3
+      const decision = brain.makeDecision(context);
+      expect(decision).toBe('hit');
+      
+      mockRandom.mockRestore();
+    });
+
+    it('should take insurance with high count vs dealer Ace', () => {
+      const brain = createHardCpuBrain();
+      
+      // Simulate very high card rich deck
+      const mockRandom = vi.spyOn(Math, 'random');
+      mockRandom.mockReturnValue(0.95);
+      
+      const context: DecisionContext = {
+        hand: createMockHand([createMockCard('10'), createMockCard('10')], 20),
+        dealerUpCard: createMockCard('A'),
+        canDouble: false,
+        canSplit: false,
+        canSurrender: false,
+        canInsurance: true,
+      };
+      
+      // Should take insurance with very high count
+      const decision = brain.makeDecision(context);
+      expect(decision).toBe('insurance');
+      
+      mockRandom.mockRestore();
+    });
+  });
+
+  describe('createCpuBrain', () => {
+    it('should create easy CPU brain', () => {
+      const brain = createCpuBrain('cpu-easy');
+      expect(brain.type).toBe('cpu-easy');
+    });
+
+    it('should create normal CPU brain', () => {
+      const brain = createCpuBrain('cpu-normal');
+      expect(brain.type).toBe('cpu-normal');
+    });
+
+    it('should create hard CPU brain', () => {
+      const brain = createCpuBrain('cpu-hard');
+      expect(brain.type).toBe('cpu-hard');
+    });
+
+    it('should throw error for invalid brain type', () => {
+      expect(() => createCpuBrain('invalid' as BrainType)).toThrow('Invalid CPU brain type: invalid');
+    });
+
+    it('should throw error for human brain type', () => {
+      expect(() => createCpuBrain('human' as BrainType)).toThrow('Invalid CPU brain type: human');
+    });
+  });
+});

--- a/src/domains/blackjack/brain/cpuBrain.ts
+++ b/src/domains/blackjack/brain/cpuBrain.ts
@@ -41,13 +41,14 @@ export const createNormalCpuBrain = (): Brain => ({
 });
 
 /**
- * Creates a hard CPU brain that uses card counting hints and deviations
+ * Creates a hard CPU brain that uses card counting hints and deviations.
+ * Accepts an optional RNG function for deterministic testing.
  */
-export const createHardCpuBrain = (): Brain => ({
+export const createHardCpuBrain = (rng: () => number = Math.random): Brain => ({
   type: 'cpu-hard',
   makeDecision: (context: DecisionContext): Decision => {
     // Simulate card counting with random value (in real game, this would track actual cards)
-    const count = Math.random() * 2 - 1; // Range from -1 to 1
+    const count = rng() * 2 - 1; // Range from -1 to 1
     
     // High positive count means deck is rich in high cards (10s and Aces)
     // Negative count means deck is rich in low cards
@@ -101,7 +102,7 @@ export const createCpuBrain = (type: BrainType): Brain => {
     case 'cpu-hard':
       return createHardCpuBrain();
     default:
-      throw new Error(`Invalid CPU brain type: ${type}`);
+      throw new Error(`Invalid CPU brain type: ${type}. Valid types are: cpu-easy, cpu-normal, cpu-hard`);
   }
 };
 


### PR DESCRIPTION
## 概要
Issue #11 に基づき、ブラックジャックにおける意思決定ロジックを管理するBrainドメインを実装しました。

## 実装内容
### 1. 型定義 (brain.types.ts)
- `Decision`: 可能な決定（hit, stand, double, split, surrender, insurance）
- `BrainType`: プレイヤータイプ（human, cpu-easy, cpu-normal, cpu-hard）
- `DecisionContext`: 意思決定に必要なコンテキスト情報
- `Brain`: 意思決定インターフェース

### 2. 基本ユーティリティ (brain.utils.ts)
- 人間プレイヤー用のBrain作成
- 決定の有効性検証
- コンテキストの妥当性検証
- 利用可能な決定の取得

### 3. 基本戦略 (basicStrategy.ts)
- 数学的に最適なブラックジャック基本戦略の完全実装
- ハードハンド、ソフトハンド、ペアに対する戦略テーブル
- 状況に応じた決定の生成

### 4. CPU AI (cpuBrain.ts)
- **Easy CPU**: ランダム性を含む簡単なAI（手札の強さに基づくバイアス付き）
- **Normal CPU**: 基本戦略に完全に従うAI
- **Hard CPU**: カードカウンティングのヒントを使用する高度なAI

### 5. Storybook (brain.stories.tsx)
- 基本戦略テーブルの可視化
- インタラクティブな決定シミュレーター

## テスト結果
- ✅ すべてのユニットテストが通過（52テスト）
- ✅ TypeScriptの型チェックが成功
- ✅ ESLintチェックが成功

## 確認方法
1. `npm run storybook` でStorybookを起動
2. Domains/Blackjack/Brain セクションで戦略テーブルとシミュレーターを確認
3. `npm run test src/domains/blackjack/brain/` でテストを実行

🤖 Generated with [Claude Code](https://claude.ai/code)