### PR TITLE
[Feature] blackjack/action-buttons コンポーネントの実装

### DIFF
--- a/src/domains/blackjack/action-buttons/actionButtons.module.css
+++ b/src/domains/blackjack/action-buttons/actionButtons.module.css
@@ -1,0 +1,94 @@
+.container {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.button {
+  min-width: 90px;
+  padding: 0.625rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hit {
+  background-color: #10b981;
+  color: white;
+}
+
+.hit:hover:not(:disabled) {
+  background-color: #059669;
+}
+
+.stand {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.stand:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.double {
+  background-color: #f59e0b;
+  color: white;
+}
+
+.double:hover:not(:disabled) {
+  background-color: #d97706;
+}
+
+.split {
+  background-color: #8b5cf6;
+  color: white;
+}
+
+.split:hover:not(:disabled) {
+  background-color: #7c3aed;
+}
+
+.surrender {
+  background-color: #ef4444;
+  color: white;
+}
+
+.surrender:hover:not(:disabled) {
+  background-color: #dc2626;
+}
+
+@media (max-width: 640px) {
+  .container {
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .button {
+    min-width: 80px;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+  }
+}

--- a/src/domains/blackjack/action-buttons/actionButtons.stories.tsx
+++ b/src/domains/blackjack/action-buttons/actionButtons.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActionButtonsView } from './actionButtons.view';
+import { useState } from 'react';
+import type { GameAction } from '../game-controller/gameController.types';
+import type { ActionButtonsProps } from './actionButtons.types';
+
+const meta = {
+  title: 'Domains/Blackjack/ActionButtons',
+  component: ActionButtonsView,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    participantId: {
+      control: 'text',
+      description: 'ID of the participant',
+    },
+    canHit: {
+      control: 'boolean',
+      description: 'Whether the Hit action is available',
+    },
+    canStand: {
+      control: 'boolean',
+      description: 'Whether the Stand action is available',
+    },
+    canDouble: {
+      control: 'boolean',
+      description: 'Whether the Double action is available',
+    },
+    canSplit: {
+      control: 'boolean',
+      description: 'Whether the Split action is available',
+    },
+    canSurrender: {
+      control: 'boolean',
+      description: 'Whether the Surrender action is available',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether all buttons are disabled',
+    },
+  },
+} satisfies Meta<typeof ActionButtonsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllActionsAvailable: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: true,
+    canSplit: true,
+    canSurrender: true,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: false,
+  },
+};
+
+export const BasicActionsOnly: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: false,
+    canSplit: false,
+    canSurrender: false,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: false,
+  },
+};
+
+export const FirstTurnOptions: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: true,
+    canSplit: false,
+    canSurrender: true,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: false,
+  },
+};
+
+export const SplitAvailable: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: true,
+    canSplit: true,
+    canSurrender: false,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: false,
+  },
+};
+
+export const OnlyStandAvailable: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: false,
+    canStand: true,
+    canDouble: false,
+    canSplit: false,
+    canSurrender: false,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: false,
+  },
+};
+
+export const AllDisabled: Story = {
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: true,
+    canSplit: true,
+    canSurrender: true,
+    onAction: (action: GameAction) => console.log('Action:', action),
+    disabled: true,
+  },
+};
+
+const InteractiveComponent = (args: ActionButtonsProps) => {
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const [actionCount, setActionCount] = useState(0);
+
+  const handleAction = (action: GameAction) => {
+    setLastAction(action.type);
+    setActionCount(count => count + 1);
+    console.log('Action:', action);
+  };
+
+    return (
+      <div style={{ 
+        display: 'flex', 
+        flexDirection: 'column', 
+        alignItems: 'center', 
+        gap: '2rem',
+        padding: '2rem',
+        background: '#f3f4f6',
+        borderRadius: '8px',
+        minWidth: '400px',
+      }}>
+        <h3 style={{ margin: 0 }}>Interactive Action Buttons Demo</h3>
+        
+        <ActionButtonsView {...args} onAction={handleAction} />
+        
+        <div style={{ 
+          textAlign: 'center',
+          padding: '1rem',
+          background: 'white',
+          borderRadius: '4px',
+          width: '100%',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        }}>
+          <p style={{ margin: '0 0 0.5rem 0', fontWeight: 600 }}>
+            Last Action: {lastAction || 'None'}
+          </p>
+          <p style={{ margin: 0, color: '#6b7280' }}>
+            Total Actions: {actionCount}
+          </p>
+        </div>
+      </div>
+    );
+};
+
+export const Interactive: Story = {
+  render: InteractiveComponent,
+  args: {
+    participantId: 'player-1',
+    canHit: true,
+    canStand: true,
+    canDouble: true,
+    canSplit: false,
+    canSurrender: false,
+    onAction: () => {}, // Will be overridden in the component
+    disabled: false,
+  },
+};

--- a/src/domains/blackjack/action-buttons/actionButtons.types.ts
+++ b/src/domains/blackjack/action-buttons/actionButtons.types.ts
@@ -1,0 +1,12 @@
+import type { GameAction } from '../game-controller/gameController.types';
+
+export type ActionButtonsProps = {
+  readonly participantId: string;
+  readonly canHit: boolean;
+  readonly canStand: boolean;
+  readonly canDouble: boolean;
+  readonly canSplit: boolean;
+  readonly canSurrender: boolean;
+  readonly onAction: (action: GameAction) => void;
+  readonly disabled?: boolean;
+};

--- a/src/domains/blackjack/action-buttons/actionButtons.view.test.tsx
+++ b/src/domains/blackjack/action-buttons/actionButtons.view.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ActionButtonsView } from './actionButtons.view';
+import type { ActionButtonsProps } from './actionButtons.types';
+
+
+describe('ActionButtonsView', () => {
+  const defaultProps: ActionButtonsProps = {
+    participantId: 'test-player',
+    canHit: true,
+    canStand: true,
+    canDouble: false,
+    canSplit: false,
+    canSurrender: false,
+    onAction: vi.fn(),
+    disabled: false,
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ボタンの表示', () => {
+    it('Hitボタンが有効な場合、表示される', () => {
+      render(<ActionButtonsView {...defaultProps} canHit={true} />);
+      const hitButton = screen.getByRole('button', { name: /hit/i });
+      expect(hitButton).toBeInTheDocument();
+      expect(hitButton).not.toBeDisabled();
+    });
+
+    it('Standボタンが有効な場合、表示される', () => {
+      render(<ActionButtonsView {...defaultProps} canStand={true} />);
+      const standButton = screen.getByRole('button', { name: /stand/i });
+      expect(standButton).toBeInTheDocument();
+      expect(standButton).not.toBeDisabled();
+    });
+
+    it('Doubleボタンが有効な場合、表示される', () => {
+      render(<ActionButtonsView {...defaultProps} canDouble={true} />);
+      const doubleButton = screen.getByRole('button', { name: /double/i });
+      expect(doubleButton).toBeInTheDocument();
+      expect(doubleButton).not.toBeDisabled();
+    });
+
+    it('Splitボタンが有効な場合、表示される', () => {
+      render(<ActionButtonsView {...defaultProps} canSplit={true} />);
+      const splitButton = screen.getByRole('button', { name: /split/i });
+      expect(splitButton).toBeInTheDocument();
+      expect(splitButton).not.toBeDisabled();
+    });
+
+    it('Surrenderボタンが有効な場合、表示される', () => {
+      render(<ActionButtonsView {...defaultProps} canSurrender={true} />);
+      const surrenderButton = screen.getByRole('button', { name: /surrender/i });
+      expect(surrenderButton).toBeInTheDocument();
+      expect(surrenderButton).not.toBeDisabled();
+    });
+  });
+
+  describe('ボタンの無効化', () => {
+    it('canHitがfalseの場合、Hitボタンが無効', () => {
+      render(<ActionButtonsView {...defaultProps} canHit={false} />);
+      const hitButton = screen.getByRole('button', { name: /hit/i });
+      expect(hitButton).toBeDisabled();
+    });
+
+    it('disabledがtrueの場合、すべてのボタンが無効', () => {
+      render(<ActionButtonsView {...defaultProps} 
+        canHit={true}
+        canStand={true}
+        canDouble={true}
+        canSplit={true}
+        canSurrender={true}
+        disabled={true} 
+      />);
+      
+      const buttons = screen.getAllByRole('button');
+      buttons.forEach(button => {
+        expect(button).toBeDisabled();
+      });
+    });
+  });
+
+  describe('アクションの実行', () => {
+    it('Hitボタンをクリックすると、onActionがhitアクションで呼ばれる', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} onAction={onAction} />);
+      
+      const hitButton = screen.getByRole('button', { name: /hit/i });
+      fireEvent.click(hitButton);
+      
+      expect(onAction).toHaveBeenCalledWith({ type: 'hit' });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('Standボタンをクリックすると、onActionがstandアクションで呼ばれる', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} onAction={onAction} />);
+      
+      const standButton = screen.getByRole('button', { name: /stand/i });
+      fireEvent.click(standButton);
+      
+      expect(onAction).toHaveBeenCalledWith({ type: 'stand' });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('Doubleボタンをクリックすると、onActionがdoubleアクションで呼ばれる', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} canDouble={true} onAction={onAction} />);
+      
+      const doubleButton = screen.getByRole('button', { name: /double/i });
+      fireEvent.click(doubleButton);
+      
+      expect(onAction).toHaveBeenCalledWith({ type: 'double' });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('Splitボタンをクリックすると、onActionがsplitアクションで呼ばれる', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} canSplit={true} onAction={onAction} />);
+      
+      const splitButton = screen.getByRole('button', { name: /split/i });
+      fireEvent.click(splitButton);
+      
+      expect(onAction).toHaveBeenCalledWith({ type: 'split' });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('Surrenderボタンをクリックすると、onActionがsurrenderアクションで呼ばれる', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} canSurrender={true} onAction={onAction} />);
+      
+      const surrenderButton = screen.getByRole('button', { name: /surrender/i });
+      fireEvent.click(surrenderButton);
+      
+      expect(onAction).toHaveBeenCalledWith({ type: 'surrender' });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('無効なボタンをクリックしても、onActionが呼ばれない', () => {
+      const onAction = vi.fn();
+      render(<ActionButtonsView {...defaultProps} canHit={false} onAction={onAction} />);
+      
+      const hitButton = screen.getByRole('button', { name: /hit/i });
+      fireEvent.click(hitButton);
+      
+      expect(onAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('すべてのボタンに適切なaria-labelが設定されている', () => {
+      render(<ActionButtonsView {...defaultProps} 
+        canHit={true}
+        canStand={true}
+        canDouble={true}
+        canSplit={true}
+        canSurrender={true}
+      />);
+      
+      expect(screen.getByRole('button', { name: /hit/i })).toHaveAttribute('aria-label');
+      expect(screen.getByRole('button', { name: /stand/i })).toHaveAttribute('aria-label');
+      expect(screen.getByRole('button', { name: /double/i })).toHaveAttribute('aria-label');
+      expect(screen.getByRole('button', { name: /split/i })).toHaveAttribute('aria-label');
+      expect(screen.getByRole('button', { name: /surrender/i })).toHaveAttribute('aria-label');
+    });
+
+    it('ボタンコンテナに適切なroleとaria-labelが設定されている', () => {
+      render(<ActionButtonsView {...defaultProps} />);
+      
+      const container = screen.getByRole('group', { name: /player actions/i });
+      expect(container).toBeInTheDocument();
+    });
+  });
+});

--- a/src/domains/blackjack/action-buttons/actionButtons.view.tsx
+++ b/src/domains/blackjack/action-buttons/actionButtons.view.tsx
@@ -1,0 +1,68 @@
+import type { FC } from 'react';
+import type { ActionButtonsProps } from './actionButtons.types';
+import styles from './actionButtons.module.css';
+
+export const ActionButtonsView: FC<ActionButtonsProps> = ({
+  canHit,
+  canStand,
+  canDouble,
+  canSplit,
+  canSurrender,
+  onAction,
+  disabled = false,
+}) => {
+  const handleAction = (type: 'hit' | 'stand' | 'double' | 'split' | 'surrender') => {
+    if (!disabled) {
+      onAction({ type });
+    }
+  };
+
+  return (
+    <div className={styles.container} role="group" aria-label="Player actions">
+      <button
+        className={`${styles.button} ${styles.hit}`}
+        onClick={() => handleAction('hit')}
+        disabled={!canHit || disabled}
+        aria-label="Hit - Draw another card"
+      >
+        Hit
+      </button>
+      
+      <button
+        className={`${styles.button} ${styles.stand}`}
+        onClick={() => handleAction('stand')}
+        disabled={!canStand || disabled}
+        aria-label="Stand - Keep current hand"
+      >
+        Stand
+      </button>
+      
+      <button
+        className={`${styles.button} ${styles.double}`}
+        onClick={() => handleAction('double')}
+        disabled={!canDouble || disabled}
+        aria-label="Double - Double bet and draw one more card"
+      >
+        Double
+      </button>
+      
+      <button
+        className={`${styles.button} ${styles.split}`}
+        onClick={() => handleAction('split')}
+        disabled={!canSplit || disabled}
+        aria-label="Split - Split pair into two hands"
+      >
+        Split
+      </button>
+      
+      <button
+        className={`${styles.button} ${styles.surrender}`}
+        onClick={() => handleAction('surrender')}
+        disabled={!canSurrender || disabled}
+        aria-label="Surrender - Give up half your bet"
+      >
+        Surrender
+      </button>
+    </div>
+  );
+};

--- a/src/domains/blackjack/game-controller/gameController.view.test.tsx
+++ b/src/domains/blackjack/game-controller/gameController.view.test.tsx
@@ -90,7 +90,7 @@ describe("GameTableView", () => {
       });
       
       render(<GameTableView />);
-      expect(screen.getByLabelText("Action buttons")).toBeInTheDocument();
+      expect(screen.getByLabelText("Player actions")).toBeInTheDocument();
     });
   });
 

--- a/src/domains/blackjack/game-controller/gameController.view.tsx
+++ b/src/domains/blackjack/game-controller/gameController.view.tsx
@@ -1,6 +1,8 @@
 import { FC } from "react";
 import { useGameController } from "./gameController.hook";
 import { HandView } from "../hand/hand.view";
+import { ActionButtonsView } from "../action-buttons/actionButtons.view";
+import type { GameAction } from "./gameController.types";
 import styles from "./gameController.module.css";
 
 export const GameTableView: FC = () => {
@@ -37,9 +39,9 @@ export const GameTableView: FC = () => {
     }
   };
 
-  const handleActionClick = (action: "hit" | "stand" | "double" | "split" | "surrender") => {
+  const handleActionClick = (action: GameAction) => {
     if (currentParticipant) {
-      handlePlayerAction(currentParticipant.id, { type: action });
+      handlePlayerAction(currentParticipant.id, action);
     }
   };
 
@@ -96,29 +98,16 @@ export const GameTableView: FC = () => {
 
       {/* Action Buttons Area */}
       {isGameInProgress && currentParticipant && phase === "playing" && (
-        <div className={styles.actionButtons} aria-label="Action buttons">
-          <button
-            onClick={() => handleActionClick("hit")}
-            disabled={!canPerformAction(currentParticipant.id, { type: "hit" })}
-            className={styles.actionButton}
-          >
-            Hit
-          </button>
-          <button
-            onClick={() => handleActionClick("stand")}
-            disabled={!canPerformAction(currentParticipant.id, { type: "stand" })}
-            className={styles.actionButton}
-          >
-            Stand
-          </button>
-          <button
-            onClick={() => handleActionClick("double")}
-            disabled={!canPerformAction(currentParticipant.id, { type: "double" })}
-            className={styles.actionButton}
-          >
-            Double
-          </button>
-        </div>
+        <ActionButtonsView
+          participantId={currentParticipant.id}
+          canHit={canPerformAction(currentParticipant.id, { type: "hit" })}
+          canStand={canPerformAction(currentParticipant.id, { type: "stand" })}
+          canDouble={canPerformAction(currentParticipant.id, { type: "double" })}
+          canSplit={canPerformAction(currentParticipant.id, { type: "split" })}
+          canSurrender={canPerformAction(currentParticipant.id, { type: "surrender" })}
+          onAction={handleActionClick}
+          disabled={false}
+        />
       )}
 
       {/* Game Control Buttons */}


### PR DESCRIPTION
## Summary
- ブラックジャックゲームのアクションボタンコンポーネントを実装しました
- Hit、Stand、Double、Split、Surrenderの5つのボタンを含みます
- ゲーム状態に応じた有効/無効制御とアクセシビリティ対応を実装

## 実装内容

### コンポーネント実装
- `ActionButtonsView`: 5つのアクションボタンを含むビューコンポーネント
- 各ボタンの有効/無効状態をpropsで制御
- クリック時に`onAction`コールバックを実行

### スタイリング
- 各ボタンに独自の色を設定（Hit: 緑、Stand: 青、Double: オレンジ、Split: 紫、Surrender: 赤）
- ホバー効果とアクティブ状態のスタイル
- レスポンシブデザイン対応

### テスト
- TDDアプローチで実装
- ボタンの表示/非表示テスト
- クリックイベントのテスト
- アクセシビリティのテスト（aria-label、role属性）

### Storybook
- 全アクション利用可能、基本アクションのみ、初回ターンオプションなど各種状態
- インタラクティブデモでアクションの動作確認が可能

### GameControllerとの統合
- 既存のボタンセクションをActionButtonsコンポーネントで置き換え
- `canPerformAction`関数を使用して各アクションの可否を判定

## Test plan
- [x] `npm run lint`でエラーがないことを確認
- [x] `npm run typecheck`で型エラーがないことを確認
- [x] `npm run test`で全テストがパスすることを確認
- [x] Storybookでコンポーネントの動作を確認
- [ ] ゲーム画面でアクションボタンが正しく動作することを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)