### PR TITLE
feat: Implement blackjack game-result component

### DIFF
--- a/src/domains/blackjack/game-result/gameResult.module.css
+++ b/src/domains/blackjack/game-result/gameResult.module.css
@@ -1,0 +1,239 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.title {
+  text-align: center;
+  color: #333;
+  margin: 0;
+}
+
+.dealerSection {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.dealerCard {
+  background-color: #2c3e50;
+  color: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: center;
+  min-width: 250px;
+}
+
+.dealerTitle {
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.resultsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.resultCard {
+  background-color: white;
+  border: 2px solid;
+  border-radius: 8px;
+  padding: 1.5rem;
+  transition: transform 0.2s;
+}
+
+.resultCard:hover {
+  transform: translateY(-2px);
+}
+
+.resultCard.win {
+  border-color: #27ae60;
+  background-color: #e8f5e9;
+}
+
+.resultCard.lose {
+  border-color: #e74c3c;
+  background-color: #ffebee;
+}
+
+.resultCard.push {
+  border-color: #f39c12;
+  background-color: #fff8e1;
+}
+
+.resultCard.blackjack {
+  border-color: #9b59b6;
+  background-color: #f3e5f5;
+  animation: pulse 1s ease-in-out;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.playerName {
+  font-size: 1.1rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.resultLabel {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.win .resultLabel {
+  color: #27ae60;
+}
+
+.lose .resultLabel {
+  color: #e74c3c;
+}
+
+.push .resultLabel {
+  color: #f39c12;
+}
+
+.blackjack .resultLabel {
+  color: #9b59b6;
+}
+
+.handInfo {
+  margin-bottom: 1rem;
+}
+
+.cards {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.card {
+  background-color: #f5f5f5;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  border: 1px solid #ddd;
+}
+
+.handValue {
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #555;
+}
+
+.betInfo {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 1rem;
+  border-top: 1px solid #eee;
+}
+
+.bet {
+  color: #666;
+}
+
+.winAmount {
+  font-weight: bold;
+}
+
+.win .winAmount,
+.blackjack .winAmount {
+  color: #27ae60;
+}
+
+.lose .winAmount {
+  color: #e74c3c;
+}
+
+.push .winAmount {
+  color: #f39c12;
+}
+
+.summary {
+  text-align: center;
+  padding: 1rem;
+  background-color: white;
+  border-radius: 8px;
+  border: 2px solid #3498db;
+}
+
+.totalDisplay {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #333;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.nextRoundButton,
+.endGameButton {
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: bold;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.nextRoundButton {
+  background-color: #3498db;
+  color: white;
+}
+
+.nextRoundButton:hover {
+  background-color: #2980b9;
+}
+
+.endGameButton {
+  background-color: #e74c3c;
+  color: white;
+}
+
+.endGameButton:hover {
+  background-color: #c0392b;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .resultsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .nextRoundButton,
+  .endGameButton {
+    width: 100%;
+  }
+}

--- a/src/domains/blackjack/game-result/gameResult.stories.tsx
+++ b/src/domains/blackjack/game-result/gameResult.stories.tsx
@@ -1,0 +1,338 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { GameResult } from "./gameResult.view";
+import type { Hand } from "../hand/hand.types";
+import type { Card, Rank, Suit } from "../../core/card/card.types";
+
+const meta: Meta<typeof GameResult> = {
+  title: "Blackjack/GameResult",
+  component: GameResult,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    onNextRound: { action: "next round clicked" },
+    onEndGame: { action: "end game clicked" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createCard = (rank: Rank, suit: Suit): Card => ({
+  rank,
+  suit,
+  faceUp: true,
+});
+
+const createHand = (cards: Card[], value: number, isBlackjack = false): Hand => ({
+  cards,
+  value,
+  isBust: value > 21,
+  isBlackjack,
+});
+
+const dealerHand17: Hand = createHand(
+  [createCard("10", "hearts"), createCard("7", "diamonds")],
+  17
+);
+
+const dealerHand21: Hand = createHand(
+  [createCard("K", "spades"), createCard("A", "clubs")],
+  21,
+  true
+);
+
+const dealerBust: Hand = createHand(
+  [
+    createCard("10", "hearts"),
+    createCard("8", "diamonds"),
+    createCard("5", "clubs"),
+  ],
+  23
+);
+
+export const SingleWin: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("K", "hearts"), createCard("Q", "spades")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+    ],
+  },
+};
+
+export const SingleLose: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("10", "hearts"), createCard("6", "diamonds")],
+          16
+        ),
+        bet: { value: 50 },
+        winAmount: { value: -50 },
+        result: "lose",
+      },
+    ],
+  },
+};
+
+export const Push: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("9", "clubs"), createCard("8", "hearts")],
+          17
+        ),
+        bet: { value: 75 },
+        winAmount: { value: 0 },
+        result: "push",
+      },
+    ],
+  },
+};
+
+export const PlayerBlackjack: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Lucky Player",
+        finalHand: createHand(
+          [createCard("A", "spades"), createCard("K", "hearts")],
+          21,
+          true
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 150 },
+        result: "blackjack",
+      },
+    ],
+  },
+};
+
+export const DealerBlackjack: Story = {
+  args: {
+    dealerHand: dealerHand21,
+    results: [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("K", "hearts"), createCard("Q", "spades")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: -100 },
+        result: "lose",
+      },
+      {
+        participantId: "player2",
+        name: "Player 2",
+        finalHand: createHand(
+          [createCard("A", "diamonds"), createCard("K", "clubs")],
+          21,
+          true
+        ),
+        bet: { value: 50 },
+        winAmount: { value: 0 },
+        result: "push",
+      },
+    ],
+  },
+};
+
+export const PlayerBust: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Busted Player",
+        finalHand: createHand(
+          [
+            createCard("10", "hearts"),
+            createCard("8", "diamonds"),
+            createCard("5", "clubs"),
+          ],
+          23
+        ),
+        bet: { value: 100 },
+        winAmount: { value: -100 },
+        result: "lose",
+      },
+    ],
+  },
+};
+
+export const DealerBustAllWin: Story = {
+  args: {
+    dealerHand: dealerBust,
+    results: [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("K", "hearts"), createCard("Q", "spades")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+      {
+        participantId: "player2",
+        name: "Player 2",
+        finalHand: createHand(
+          [createCard("10", "diamonds"), createCard("8", "clubs")],
+          18
+        ),
+        bet: { value: 50 },
+        winAmount: { value: 50 },
+        result: "win",
+      },
+    ],
+  },
+};
+
+export const MultipleResults: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Winner",
+        finalHand: createHand(
+          [createCard("K", "hearts"), createCard("Q", "spades")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+      {
+        participantId: "player2",
+        name: "Loser",
+        finalHand: createHand(
+          [createCard("10", "hearts"), createCard("5", "diamonds")],
+          15
+        ),
+        bet: { value: 50 },
+        winAmount: { value: -50 },
+        result: "lose",
+      },
+      {
+        participantId: "player3",
+        name: "Tied",
+        finalHand: createHand(
+          [createCard("9", "clubs"), createCard("8", "hearts")],
+          17
+        ),
+        bet: { value: 75 },
+        winAmount: { value: 0 },
+        result: "push",
+      },
+      {
+        participantId: "player4",
+        name: "Blackjack Winner",
+        finalHand: createHand(
+          [createCard("A", "spades"), createCard("J", "diamonds")],
+          21,
+          true
+        ),
+        bet: { value: 200 },
+        winAmount: { value: 300 },
+        result: "blackjack",
+      },
+    ],
+  },
+};
+
+export const FoldedPlayers: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Active Player",
+        finalHand: createHand(
+          [createCard("K", "hearts"), createCard("Q", "spades")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+      {
+        participantId: "player2",
+        name: "Folded Player",
+        finalHand: null,
+        bet: null,
+        winAmount: null,
+        result: "lose",
+      },
+    ],
+  },
+};
+
+export const EmptyResults: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [],
+  },
+};
+
+export const AllBusted: Story = {
+  args: {
+    dealerHand: dealerHand17,
+    results: [
+      {
+        participantId: "player1",
+        name: "Busted 1",
+        finalHand: createHand(
+          [
+            createCard("10", "hearts"),
+            createCard("8", "diamonds"),
+            createCard("6", "clubs"),
+          ],
+          24
+        ),
+        bet: { value: 100 },
+        winAmount: { value: -100 },
+        result: "lose",
+      },
+      {
+        participantId: "player2",
+        name: "Busted 2",
+        finalHand: createHand(
+          [
+            createCard("K", "spades"),
+            createCard("Q", "hearts"),
+            createCard("5", "diamonds"),
+          ],
+          25
+        ),
+        bet: { value: 50 },
+        winAmount: { value: -50 },
+        result: "lose",
+      },
+    ],
+  },
+};

--- a/src/domains/blackjack/game-result/gameResult.types.ts
+++ b/src/domains/blackjack/game-result/gameResult.types.ts
@@ -1,0 +1,9 @@
+import type { Hand } from "../hand/hand.types";
+import type { ParticipantResult } from "../game-controller/gameController.types";
+
+export type GameResultProps = {
+  results: ParticipantResult[];
+  dealerHand: Hand;
+  onNextRound: () => void;
+  onEndGame: () => void;
+};

--- a/src/domains/blackjack/game-result/gameResult.view.test.tsx
+++ b/src/domains/blackjack/game-result/gameResult.view.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { GameResult } from "./gameResult.view";
+import type { GameResultProps } from "./gameResult.types";
+import type { ParticipantResult } from "../game-controller/gameController.types";
+import type { Hand } from "../hand/hand.types";
+import type { Card, Rank, Suit } from "../../core/card/card.types";
+
+describe("GameResult", () => {
+  const createCard = (rank: Rank, suit: Suit): Card => ({
+    rank,
+    suit,
+    faceUp: true,
+  });
+
+  const createHand = (cards: Card[], value: number, isBlackjack = false): Hand => ({
+    cards,
+    value,
+    isBust: value > 21,
+    isBlackjack,
+  });
+
+  const mockDealerHand: Hand = createHand(
+    [createCard("10", "hearts"), createCard("7", "diamonds")],
+    17
+  );
+
+  const defaultProps: GameResultProps = {
+    results: [],
+    dealerHand: mockDealerHand,
+    onNextRound: vi.fn(),
+    onEndGame: vi.fn(),
+  };
+
+  it("displays win result with winning amount", () => {
+    const winResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: createHand(
+        [createCard("Q", "spades"), createCard("K", "clubs")],
+        20
+      ),
+      bet: { value: 100 },
+      winAmount: { value: 100 },
+      result: "win",
+    };
+
+    render(<GameResult {...defaultProps} results={[winResult]} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("WIN")).toBeInTheDocument();
+    expect(screen.getByText("Bet: 100")).toBeInTheDocument();
+    expect(screen.getByText("Won: +100")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument(); // Player hand value
+  });
+
+  it("displays lose result with lost amount", () => {
+    const loseResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: createHand(
+        [createCard("10", "hearts"), createCard("6", "diamonds")],
+        16
+      ),
+      bet: { value: 50 },
+      winAmount: { value: -50 },
+      result: "lose",
+    };
+
+    render(<GameResult {...defaultProps} results={[loseResult]} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("LOSE")).toBeInTheDocument();
+    expect(screen.getByText("Bet: 50")).toBeInTheDocument();
+    expect(screen.getByText("Lost: -50")).toBeInTheDocument();
+    expect(screen.getByText("16")).toBeInTheDocument();
+  });
+
+  it("displays push result with no win/loss", () => {
+    const pushResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: createHand(
+        [createCard("10", "hearts"), createCard("7", "diamonds")],
+        17
+      ),
+      bet: { value: 75 },
+      winAmount: { value: 0 },
+      result: "push",
+    };
+
+    render(<GameResult {...defaultProps} results={[pushResult]} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("PUSH")).toBeInTheDocument();
+    expect(screen.getByText("Bet: 75")).toBeInTheDocument();
+    expect(screen.getByText("Push: 0")).toBeInTheDocument();
+    expect(screen.getAllByText("17")).toHaveLength(2); // Dealer and player both have 17
+  });
+
+  it("displays blackjack result with 3:2 payout", () => {
+    const blackjackResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: createHand(
+        [createCard("A", "spades"), createCard("K", "hearts")],
+        21,
+        true
+      ),
+      bet: { value: 100 },
+      winAmount: { value: 150 },
+      result: "blackjack",
+    };
+
+    render(<GameResult {...defaultProps} results={[blackjackResult]} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("BLACKJACK!")).toBeInTheDocument();
+    expect(screen.getByText("Bet: 100")).toBeInTheDocument();
+    expect(screen.getByText("Won: +150")).toBeInTheDocument();
+    expect(screen.getByText("Blackjack")).toBeInTheDocument(); // Hand value display
+  });
+
+  it("displays dealer hand information", () => {
+    render(<GameResult {...defaultProps} />);
+
+    expect(screen.getByText("Dealer")).toBeInTheDocument();
+    expect(screen.getByText("17")).toBeInTheDocument(); // Dealer hand value
+  });
+
+  it("handles bust hands correctly", () => {
+    const bustResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: createHand(
+        [
+          createCard("10", "hearts"),
+          createCard("8", "diamonds"),
+          createCard("5", "clubs"),
+        ],
+        23
+      ),
+      bet: { value: 100 },
+      winAmount: { value: -100 },
+      result: "lose",
+    };
+
+    render(<GameResult {...defaultProps} results={[bustResult]} />);
+
+    expect(screen.getByText("BUST")).toBeInTheDocument();
+    expect(screen.getByText("Lost: -100")).toBeInTheDocument();
+  });
+
+  it("displays multiple player results", () => {
+    const results: ParticipantResult[] = [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("Q", "spades"), createCard("K", "clubs")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+      {
+        participantId: "player2",
+        name: "Player 2",
+        finalHand: createHand(
+          [createCard("10", "hearts"), createCard("6", "diamonds")],
+          16
+        ),
+        bet: { value: 50 },
+        winAmount: { value: -50 },
+        result: "lose",
+      },
+    ];
+
+    render(<GameResult {...defaultProps} results={results} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("Player 2")).toBeInTheDocument();
+    expect(screen.getAllByText(/WIN|LOSE/)).toHaveLength(2);
+  });
+
+  it("calls onNextRound when Next Round button is clicked", async () => {
+    const onNextRound = vi.fn();
+    render(<GameResult {...defaultProps} onNextRound={onNextRound} />);
+
+    const nextRoundButton = screen.getByRole("button", { name: /next round/i });
+    await userEvent.click(nextRoundButton);
+
+    expect(onNextRound).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onEndGame when End Game button is clicked", async () => {
+    const onEndGame = vi.fn();
+    render(<GameResult {...defaultProps} onEndGame={onEndGame} />);
+
+    const endGameButton = screen.getByRole("button", { name: /end game/i });
+    await userEvent.click(endGameButton);
+
+    expect(onEndGame).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles participants with null hands (folded)", () => {
+    const foldedResult: ParticipantResult = {
+      participantId: "player1",
+      name: "Player 1",
+      finalHand: null,
+      bet: null,
+      winAmount: null,
+      result: "lose",
+    };
+
+    render(<GameResult {...defaultProps} results={[foldedResult]} />);
+
+    expect(screen.getByText("Player 1")).toBeInTheDocument();
+    expect(screen.getByText("FOLDED")).toBeInTheDocument();
+    expect(screen.queryByText("Bet:")).not.toBeInTheDocument();
+  });
+
+  it("displays total summary for all results", () => {
+    const results: ParticipantResult[] = [
+      {
+        participantId: "player1",
+        name: "Player 1",
+        finalHand: createHand(
+          [createCard("Q", "spades"), createCard("K", "clubs")],
+          20
+        ),
+        bet: { value: 100 },
+        winAmount: { value: 100 },
+        result: "win",
+      },
+      {
+        participantId: "player2",
+        name: "Player 2",
+        finalHand: createHand(
+          [createCard("10", "hearts"), createCard("6", "diamonds")],
+          16
+        ),
+        bet: { value: 50 },
+        winAmount: { value: -50 },
+        result: "lose",
+      },
+      {
+        participantId: "player3",
+        name: "Player 3",
+        finalHand: createHand(
+          [createCard("10", "clubs"), createCard("7", "spades")],
+          17
+        ),
+        bet: { value: 75 },
+        winAmount: { value: 0 },
+        result: "push",
+      },
+    ];
+
+    render(<GameResult {...defaultProps} results={results} />);
+
+    expect(screen.getByText("Total: +50")).toBeInTheDocument();
+  });
+});

--- a/src/domains/blackjack/game-result/gameResult.view.tsx
+++ b/src/domains/blackjack/game-result/gameResult.view.tsx
@@ -1,0 +1,152 @@
+import type { FC } from "react";
+import type { GameResultProps } from "./gameResult.types";
+import type { ParticipantResult } from "../game-controller/gameController.types";
+import type { Hand } from "../hand/hand.types";
+import type { Coin } from "../../core/coin/coin.types";
+import styles from "./gameResult.module.css";
+
+const getResultLabel = (result: ParticipantResult["result"]): string => {
+  switch (result) {
+    case "win":
+      return "WIN";
+    case "lose":
+      return "LOSE";
+    case "push":
+      return "PUSH";
+    case "blackjack":
+      return "BLACKJACK!";
+  }
+};
+
+const getHandValueDisplay = (hand: Hand | null): string => {
+  if (!hand) return "FOLDED";
+  if (hand.isBust) return "BUST";
+  if (hand.isBlackjack) return "Blackjack";
+  return hand.value.toString();
+};
+
+const getMoneyDisplay = (
+  result: ParticipantResult["result"],
+  amount: Coin | null
+): string => {
+  if (amount === null) return "";
+  
+  switch (result) {
+    case "win":
+    case "blackjack":
+      return `Won: +${amount.value}`;
+    case "lose":
+      return `Lost: ${amount.value}`;
+    case "push":
+      return `Push: ${amount.value}`;
+  }
+};
+
+const ResultCard: FC<{ result: ParticipantResult }> = ({ result }) => {
+  const resultClass = styles[result.result];
+  const handValue = getHandValueDisplay(result.finalHand);
+  const moneyDisplay = getMoneyDisplay(result.result, result.winAmount);
+
+  return (
+    <div className={`${styles.resultCard} ${resultClass}`}>
+      <div className={styles.playerName}>{result.name}</div>
+      <div className={styles.resultLabel}>{getResultLabel(result.result)}</div>
+      
+      {result.finalHand ? (
+        <div className={styles.handInfo}>
+          <div className={styles.cards}>
+            {result.finalHand.cards.map((card, index) => (
+              <span key={index} className={styles.card}>
+                {card.rank} {card.suit}
+              </span>
+            ))}
+          </div>
+          <div className={styles.handValue}>{handValue}</div>
+        </div>
+      ) : (
+        <div className={styles.handInfo}>
+          <div className={styles.handValue}>{handValue}</div>
+        </div>
+      )}
+      
+      {result.bet !== null && (
+        <div className={styles.betInfo}>
+          <div className={styles.bet}>Bet: {result.bet.value}</div>
+          <div className={styles.winAmount}>{moneyDisplay}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DealerCard: FC<{ hand: Hand }> = ({ hand }) => {
+  return (
+    <div className={styles.dealerCard}>
+      <div className={styles.dealerTitle}>Dealer</div>
+      <div className={styles.handInfo}>
+        <div className={styles.cards}>
+          {hand.cards.map((card, index) => (
+            <span key={index} className={styles.card}>
+              {card.rank} {card.suit}
+            </span>
+          ))}
+        </div>
+        <div className={styles.handValue}>{getHandValueDisplay(hand)}</div>
+      </div>
+    </div>
+  );
+};
+
+export const GameResult: FC<GameResultProps> = ({
+  results,
+  dealerHand,
+  onNextRound,
+  onEndGame,
+}) => {
+  const totalWinnings = results.reduce(
+    (sum, result) => sum + (result.winAmount?.value || 0),
+    0
+  );
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>Round Results</h2>
+      
+      <div className={styles.dealerSection}>
+        <DealerCard hand={dealerHand} />
+      </div>
+      
+      <div className={styles.resultsGrid}>
+        {results.map((result) => (
+          <ResultCard key={result.participantId} result={result} />
+        ))}
+      </div>
+      
+      {results.length > 0 && (
+        <div className={styles.summary}>
+          <div className={styles.totalDisplay}>
+            Total: {totalWinnings >= 0 ? "+" : ""}
+            {totalWinnings}
+          </div>
+        </div>
+      )}
+      
+      <div className={styles.actions}>
+        <button
+          className={styles.nextRoundButton}
+          onClick={onNextRound}
+          type="button"
+        >
+          Next Round
+        </button>
+        <button
+          className={styles.endGameButton}
+          onClick={onEndGame}
+          type="button"
+        >
+          End Game
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/domains/blackjack/game-result/gameResult.view.tsx
+++ b/src/domains/blackjack/game-result/gameResult.view.tsx
@@ -122,14 +122,12 @@ export const GameResult: FC<GameResultProps> = ({
         ))}
       </div>
       
-      {results.length > 0 && (
-        <div className={styles.summary}>
-          <div className={styles.totalDisplay}>
-            Total: {totalWinnings >= 0 ? "+" : ""}
-            {totalWinnings}
-          </div>
+      <div className={styles.summary}>
+        <div className={styles.totalDisplay}>
+          Total: {totalWinnings > 0 ? "+" : ""}
+          {totalWinnings}
         </div>
-      )}
+      </div>
       
       <div className={styles.actions}>
         <button


### PR DESCRIPTION
## Summary
- Implement GameResult component to display round results (#23)
- Add comprehensive game outcome visualization for blackjack rounds
- Support multiple player results with win/lose/push/blackjack status

## Implementation Details

### Components Added
- `gameResult.view.tsx` - Main view component for displaying results
- `gameResult.types.ts` - TypeScript type definitions
- `gameResult.module.css` - Responsive styling with CSS modules
- `gameResult.view.test.tsx` - Comprehensive test coverage (11 test cases)
- `gameResult.stories.tsx` - Storybook stories for all result scenarios

### Features
- ✅ Display each player's final hand and result status
- ✅ Show dealer's final hand and score
- ✅ Color-coded result cards (win: green, lose: red, push: orange, blackjack: purple)
- ✅ Betting amount and winnings/losses display
- ✅ Total summary of all player results
- ✅ Support for folded players (null hands)
- ✅ Animated blackjack wins
- ✅ Responsive design for mobile devices
- ✅ Action buttons for next round and game end

### Test Coverage
All tests passing:
- Win/Lose/Push/Blackjack result displays
- Multiple player results
- Dealer hand display
- Bust handling
- Folded player handling
- Button click events
- Total winnings calculation

## Test Plan
- [x] Run `npm run lint` - No errors
- [x] Run `npm run typecheck` - No errors  
- [x] Run `npm run test` - All tests pass (382 passed)
- [x] Check Storybook stories for visual confirmation
- [ ] Test integration with game-controller component

## Related Issues
- Closes #23
- Part of #1 (Epic: Blackjack game implementation)

🤖 Generated with [Claude Code](https://claude.ai/code)