### PR TITLE
feat: Implement blackjack game-setup component

### DIFF
--- a/src/domains/blackjack/game-setup/gameSetup.module.css
+++ b/src/domains/blackjack/game-setup/gameSetup.module.css
@@ -1,0 +1,213 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.formSection {
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #555;
+}
+
+.formGroup {
+  margin-bottom: 1rem;
+}
+
+.label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  color: #666;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #4CAF50;
+}
+
+.input:disabled {
+  background-color: #e9ecef;
+  cursor: not-allowed;
+}
+
+.checkbox {
+  margin-right: 0.5rem;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkboxLabel:hover {
+  color: #333;
+}
+
+.error {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+  display: block;
+}
+
+.addButton {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.addButton:hover:not(:disabled) {
+  background-color: #45a049;
+}
+
+.addButton:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.playersSection {
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.noPlayers {
+  text-align: center;
+  color: #999;
+  padding: 2rem;
+}
+
+.playersList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.playerItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e0e0e0;
+  transition: background-color 0.2s;
+}
+
+.playerItem:last-child {
+  border-bottom: none;
+}
+
+.playerItem:hover {
+  background-color: #f9f9f9;
+}
+
+.playerInfo {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.playerName {
+  font-weight: 600;
+  color: #333;
+  min-width: 120px;
+}
+
+.playerBalance {
+  color: #666;
+  font-family: monospace;
+}
+
+.playerType {
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: #e3f2fd;
+  color: #1976d2;
+}
+
+.playerType:has-text('AI') {
+  background-color: #fff3e0;
+  color: #f57c00;
+}
+
+.removeButton {
+  padding: 0.25rem 0.75rem;
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.removeButton:hover {
+  background-color: #d32f2f;
+}
+
+.actionSection {
+  text-align: center;
+}
+
+.startButton {
+  padding: 1rem 3rem;
+  background-color: #2196F3;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.startButton:hover:not(:disabled) {
+  background-color: #1976D2;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.startButton:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+  box-shadow: none;
+}

--- a/src/domains/blackjack/game-setup/gameSetup.module.css
+++ b/src/domains/blackjack/game-setup/gameSetup.module.css
@@ -163,7 +163,7 @@
   color: #1976d2;
 }
 
-.playerType:has-text('AI') {
+.playerTypeAI {
   background-color: #fff3e0;
   color: #f57c00;
 }

--- a/src/domains/blackjack/game-setup/gameSetup.stories.tsx
+++ b/src/domains/blackjack/game-setup/gameSetup.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GameSetup } from './gameSetup.view';
+import { action } from '@storybook/addon-actions';
+
+const meta = {
+  title: 'Domains/Blackjack/GameSetup',
+  component: GameSetup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    defaultBalance: {
+      control: { type: 'number', min: 1, max: 10000, step: 100 }
+    },
+    maxPlayers: {
+      control: { type: 'number', min: 1, max: 8, step: 1 }
+    }
+  }
+} satisfies Meta<typeof GameSetup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 1000,
+    maxPlayers: 4
+  }
+};
+
+export const WithHighDefaultBalance: Story = {
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 5000,
+    maxPlayers: 4
+  }
+};
+
+export const TwoPlayerLimit: Story = {
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 1000,
+    maxPlayers: 2
+  }
+};
+
+export const SinglePlayerOnly: Story = {
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 1000,
+    maxPlayers: 1
+  }
+};
+
+export const WithPrefilledPlayers: Story = {
+  render: (args) => {
+    return <GameSetup {...args} />;
+  },
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 1000,
+    maxPlayers: 4
+  },
+  play: async ({ canvasElement }) => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    
+    await delay(500);
+    
+    const nameInput = canvasElement.querySelector('#playerName') as HTMLInputElement;
+    const balanceInput = canvasElement.querySelector('#playerBalance') as HTMLInputElement;
+    const addButton = canvasElement.querySelector('button[class*="addButton"]') as HTMLButtonElement;
+    
+    if (nameInput && balanceInput && addButton) {
+      nameInput.value = 'プレイヤー1';
+      nameInput.dispatchEvent(new Event('change', { bubbles: true }));
+      await delay(200);
+      
+      balanceInput.value = '2000';
+      balanceInput.dispatchEvent(new Event('change', { bubbles: true }));
+      await delay(200);
+      
+      addButton.click();
+      await delay(500);
+      
+      nameInput.value = 'AIプレイヤー';
+      nameInput.dispatchEvent(new Event('change', { bubbles: true }));
+      await delay(200);
+      
+      const humanToggle = canvasElement.querySelector('#isHuman') as HTMLInputElement;
+      if (humanToggle) {
+        humanToggle.click();
+      }
+      await delay(200);
+      
+      addButton.click();
+    }
+  }
+};
+
+export const MaxPlayersReached: Story = {
+  render: (args) => {
+    return <GameSetup {...args} />;
+  },
+  args: {
+    onStartGame: action('onStartGame'),
+    defaultBalance: 1000,
+    maxPlayers: 2
+  },
+  play: async ({ canvasElement }) => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    
+    await delay(500);
+    
+    const nameInput = canvasElement.querySelector('#playerName') as HTMLInputElement;
+    const addButton = canvasElement.querySelector('button[class*="addButton"]') as HTMLButtonElement;
+    
+    if (nameInput && addButton) {
+      for (let i = 1; i <= 2; i++) {
+        nameInput.value = `プレイヤー${i}`;
+        nameInput.dispatchEvent(new Event('change', { bubbles: true }));
+        await delay(200);
+        
+        addButton.click();
+        await delay(300);
+      }
+    }
+  }
+};

--- a/src/domains/blackjack/game-setup/gameSetup.types.ts
+++ b/src/domains/blackjack/game-setup/gameSetup.types.ts
@@ -1,0 +1,23 @@
+export type ParticipantSetup = {
+  name: string;
+  balance: number;
+  isHuman: boolean;
+};
+
+export type GameSetupProps = {
+  onStartGame: (participants: ParticipantSetup[]) => void;
+  defaultBalance?: number;
+  maxPlayers?: number;
+};
+
+export type GameSetupFormData = {
+  name: string;
+  balance: string;
+  isHuman: boolean;
+};
+
+export type GameSetupFormErrors = {
+  name?: string;
+  balance?: string;
+  general?: string;
+};

--- a/src/domains/blackjack/game-setup/gameSetup.view.test.tsx
+++ b/src/domains/blackjack/game-setup/gameSetup.view.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GameSetup } from './gameSetup.view';
+import type { ParticipantSetup } from './gameSetup.types';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('GameSetup', () => {
+  const mockOnStartGame = vi.fn();
+
+  beforeEach(() => {
+    mockOnStartGame.mockClear();
+  });
+
+  it('renders the game setup form', () => {
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    expect(screen.getByText('ゲームセットアップ')).toBeInTheDocument();
+    expect(screen.getByLabelText('プレイヤー名')).toBeInTheDocument();
+    expect(screen.getByLabelText('初期残高')).toBeInTheDocument();
+    expect(screen.getByLabelText('人間プレイヤー')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'プレイヤーを追加' })).toBeInTheDocument();
+    expect(screen.getByText('ゲームを開始', { selector: 'button' })).toBeInTheDocument();
+  });
+
+  it('adds a player with valid input', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} defaultBalance={1000} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const balanceInput = screen.getByLabelText('初期残高');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.clear(balanceInput);
+    await user.type(balanceInput, '2000');
+    await user.click(addButton);
+    
+    expect(screen.getByText('プレイヤー1')).toBeInTheDocument();
+    expect(screen.getByText('¥2,000')).toBeInTheDocument();
+    expect(screen.getByText('人間')).toBeInTheDocument();
+  });
+
+  it('shows validation error for empty name', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    await user.click(addButton);
+    
+    expect(screen.getByText('プレイヤー名を入力してください')).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid balance', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const balanceInput = screen.getByLabelText('初期残高');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.clear(balanceInput);
+    await user.type(balanceInput, '0');
+    await user.click(addButton);
+    
+    expect(screen.getByText('初期残高は1以上の数値を入力してください')).toBeInTheDocument();
+  });
+
+  it('removes a player from the list', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.click(addButton);
+    
+    const removeButton = screen.getByLabelText('プレイヤー1を削除');
+    await user.click(removeButton);
+    
+    expect(screen.queryByText('プレイヤー1')).not.toBeInTheDocument();
+  });
+
+  it('prevents adding players beyond max limit', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} maxPlayers={2} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.click(addButton);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'プレイヤー2');
+    await user.click(addButton);
+    
+    expect(addButton).toBeDisabled();
+  });
+
+  it('starts the game with at least one player', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const balanceInput = screen.getByLabelText('初期残高');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    const startButton = screen.getByText('ゲームを開始', { selector: 'button' });
+    
+    expect(startButton).toBeDisabled();
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.clear(balanceInput);
+    await user.type(balanceInput, '1500');
+    await user.click(addButton);
+    
+    expect(startButton).toBeEnabled();
+    
+    await user.click(startButton);
+    
+    const expectedParticipants: ParticipantSetup[] = [
+      {
+        name: 'プレイヤー1',
+        balance: 1500,
+        isHuman: true
+      }
+    ];
+    
+    expect(mockOnStartGame).toHaveBeenCalledWith(expectedParticipants);
+  });
+
+  it('toggles between human and AI player', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名');
+    const humanToggle = screen.getByLabelText('人間プレイヤー');
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'AIプレイヤー');
+    await user.click(humanToggle);
+    await user.click(addButton);
+    
+    expect(screen.getByText('AI')).toBeInTheDocument();
+  });
+
+  it('uses default balance when provided', () => {
+    render(<GameSetup onStartGame={mockOnStartGame} defaultBalance={5000} />);
+    
+    const balanceInput = screen.getByLabelText('初期残高') as HTMLInputElement;
+    expect(balanceInput.value).toBe('5000');
+  });
+
+  it('clears form after adding a player', async () => {
+    const user = userEvent.setup();
+    render(<GameSetup onStartGame={mockOnStartGame} />);
+    
+    const nameInput = screen.getByLabelText('プレイヤー名') as HTMLInputElement;
+    const balanceInput = screen.getByLabelText('初期残高') as HTMLInputElement;
+    const humanToggle = screen.getByLabelText('人間プレイヤー') as HTMLInputElement;
+    const addButton = screen.getByRole('button', { name: 'プレイヤーを追加' });
+    
+    await user.type(nameInput, 'プレイヤー1');
+    await user.clear(balanceInput);
+    await user.type(balanceInput, '2000');
+    await user.click(humanToggle);
+    await user.click(addButton);
+    
+    expect(nameInput.value).toBe('');
+    expect(balanceInput.value).toBe('1000');
+    expect(humanToggle.checked).toBe(true);
+  });
+});

--- a/src/domains/blackjack/game-setup/gameSetup.view.tsx
+++ b/src/domains/blackjack/game-setup/gameSetup.view.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useCallback } from 'react';
+import styles from './gameSetup.module.css';
+import type { GameSetupProps, ParticipantSetup, GameSetupFormData, GameSetupFormErrors } from './gameSetup.types';
+
+export const GameSetup: React.FC<GameSetupProps> = ({
+  onStartGame,
+  defaultBalance = 1000,
+  maxPlayers = 4
+}) => {
+  const [participants, setParticipants] = useState<ParticipantSetup[]>([]);
+  const [formData, setFormData] = useState<GameSetupFormData>({
+    name: '',
+    balance: defaultBalance.toString(),
+    isHuman: true
+  });
+  const [errors, setErrors] = useState<GameSetupFormErrors>({});
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: GameSetupFormErrors = {};
+    
+    if (!formData.name.trim()) {
+      newErrors.name = 'プレイヤー名を入力してください';
+    }
+    
+    const balanceNum = parseInt(formData.balance, 10);
+    if (isNaN(balanceNum) || balanceNum < 1) {
+      newErrors.balance = '初期残高は1以上の数値を入力してください';
+    }
+    
+    if (participants.length >= maxPlayers) {
+      newErrors.general = '最大プレイヤー数に達しました';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [formData, participants.length, maxPlayers]);
+
+  const handleAddPlayer = useCallback(() => {
+    if (!validateForm()) {
+      return;
+    }
+    
+    const newParticipant: ParticipantSetup = {
+      name: formData.name.trim(),
+      balance: parseInt(formData.balance, 10),
+      isHuman: formData.isHuman
+    };
+    
+    setParticipants([...participants, newParticipant]);
+    setFormData({
+      name: '',
+      balance: defaultBalance.toString(),
+      isHuman: true
+    });
+    setErrors({});
+  }, [formData, participants, validateForm, defaultBalance]);
+
+  const handleRemovePlayer = useCallback((index: number) => {
+    setParticipants(participants.filter((_, i) => i !== index));
+    setErrors({});
+  }, [participants]);
+
+  const handleStartGame = useCallback(() => {
+    if (participants.length === 0) {
+      return;
+    }
+    onStartGame(participants);
+  }, [participants, onStartGame]);
+
+  const handleInputChange = useCallback((field: keyof GameSetupFormData, value: string | boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+    setErrors(prev => ({
+      ...prev,
+      [field]: undefined,
+      general: undefined
+    }));
+  }, []);
+
+  const canAddMore = participants.length < maxPlayers;
+  const canStartGame = participants.length > 0;
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>ゲームセットアップ</h1>
+      
+      <div className={styles.formSection}>
+        <h2 className={styles.sectionTitle}>プレイヤーを追加</h2>
+        
+        <div className={styles.formGroup}>
+          <label htmlFor="playerName" className={styles.label}>
+            プレイヤー名
+          </label>
+          <input
+            id="playerName"
+            type="text"
+            value={formData.name}
+            onChange={(e) => handleInputChange('name', e.target.value)}
+            className={styles.input}
+            disabled={!canAddMore}
+          />
+          {errors.name && <span className={styles.error}>{errors.name}</span>}
+        </div>
+        
+        <div className={styles.formGroup}>
+          <label htmlFor="playerBalance" className={styles.label}>
+            初期残高
+          </label>
+          <input
+            id="playerBalance"
+            type="number"
+            value={formData.balance}
+            onChange={(e) => handleInputChange('balance', e.target.value)}
+            className={styles.input}
+            min="1"
+            disabled={!canAddMore}
+          />
+          {errors.balance && <span className={styles.error}>{errors.balance}</span>}
+        </div>
+        
+        <div className={styles.formGroup}>
+          <label className={styles.checkboxLabel}>
+            <input
+              id="isHuman"
+              type="checkbox"
+              checked={formData.isHuman}
+              onChange={(e) => handleInputChange('isHuman', e.target.checked)}
+              className={styles.checkbox}
+              disabled={!canAddMore}
+            />
+            <span>人間プレイヤー</span>
+          </label>
+        </div>
+        
+        {errors.general && <div className={styles.error}>{errors.general}</div>}
+        
+        <button
+          onClick={handleAddPlayer}
+          disabled={!canAddMore}
+          className={styles.addButton}
+        >
+          プレイヤーを追加
+        </button>
+      </div>
+      
+      <div className={styles.playersSection}>
+        <h2 className={styles.sectionTitle}>参加プレイヤー ({participants.length}/{maxPlayers})</h2>
+        
+        {participants.length === 0 ? (
+          <p className={styles.noPlayers}>プレイヤーがまだ追加されていません</p>
+        ) : (
+          <ul className={styles.playersList}>
+            {participants.map((participant, index) => (
+              <li key={index} className={styles.playerItem}>
+                <div className={styles.playerInfo}>
+                  <span className={styles.playerName}>{participant.name}</span>
+                  <span className={styles.playerBalance}>¥{participant.balance.toLocaleString()}</span>
+                  <span className={styles.playerType}>{participant.isHuman ? '人間' : 'AI'}</span>
+                </div>
+                <button
+                  onClick={() => handleRemovePlayer(index)}
+                  className={styles.removeButton}
+                  aria-label={`${participant.name}を削除`}
+                >
+                  削除
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      
+      <div className={styles.actionSection}>
+        <button
+          onClick={handleStartGame}
+          disabled={!canStartGame}
+          className={styles.startButton}
+        >
+          ゲームを開始
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/domains/blackjack/game-setup/gameSetup.view.tsx
+++ b/src/domains/blackjack/game-setup/gameSetup.view.tsx
@@ -157,7 +157,7 @@ export const GameSetup: React.FC<GameSetupProps> = ({
                 <div className={styles.playerInfo}>
                   <span className={styles.playerName}>{participant.name}</span>
                   <span className={styles.playerBalance}>¥{participant.balance.toLocaleString()}</span>
-                  <span className={styles.playerType}>{participant.isHuman ? '人間' : 'AI'}</span>
+                  <span className={participant.isHuman ? styles.playerType : `${styles.playerType} ${styles.playerTypeAI}`}>{participant.isHuman ? '人間' : 'AI'}</span>
                 </div>
                 <button
                   onClick={() => handleRemovePlayer(index)}


### PR DESCRIPTION
## Summary
- ブラックジャックゲームのセットアップ画面を実装しました
- Issue #24 に対応

## Changes
- プレイヤー登録フォームの実装（名前、初期残高、人間/AI選択）
- プレイヤーの追加・削除機能
- フォームバリデーション（空の名前、無効な残高のチェック）
- 最大プレイヤー数の制限機能
- 包括的なテストとStorybookストーリー
- レスポンシブなスタイリング（CSS Modules）

## Test plan
- [x] すべてのユニットテストが成功
- [x] lint、typecheck が成功
- [x] Storybookでの動作確認
- [ ] 実際のゲームフローでの統合テスト

## Related
- Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)